### PR TITLE
Set golang to be installed from testing

### DIFF
--- a/build-env/docker/docker-debian-10-buster/preferences
+++ b/build-env/docker/docker-debian-10-buster/preferences
@@ -1,7 +1,11 @@
+Package: *
+Pin: release a=stable
+Pin-Priority: 800
+
 Package: golang-go
-Pin: release a=buster-backports
+Pin: release a=testing
 Pin-Priority: 900
 
 Package: golang-src
-Pin: release a=buster-backports
+Pin: release a=testing
 Pin-Priority: 900

--- a/build-env/docker/docker-debian-10-buster/sources.list.buster
+++ b/build-env/docker/docker-debian-10-buster/sources.list.buster
@@ -6,3 +6,6 @@ deb http://security.debian.org/debian-security buster/updates main
 deb http://deb.debian.org/debian buster-updates main
 
 deb [arch=amd64] http://deb.debian.org/debian buster-backports main
+
+# testing for golang
+deb http://deb.debian.org/debian testing main


### PR DESCRIPTION
It turns out that the 1.14 in backports is too early.  We want at least
1.14.4.  So let's set apt preferences to install golang from testing
which is currently 1.14.7.