### PR TITLE
Build depending on golang >= 1.14.4

### DIFF
--- a/devicedb/deb/debian/control
+++ b/devicedb/deb/debian/control
@@ -2,7 +2,7 @@ Source: devicedb
 Section: database
 Priority: optional
 Maintainer: Vasily Smirnov <vasilii.smirnov@globallogic.com>
-Build-Depends: debhelper (>=9), golang-go:native (>=2:1.9~), libc6
+Build-Depends: debhelper (>=9), golang-go:native (>=2:1.14~), golang-go:native (<<2:1.15~), libc6
 Standards-Version: 3.9.6
 Homepage: https://www.pelion.com
 

--- a/edge-proxy/deb/debian/control
+++ b/edge-proxy/deb/debian/control
@@ -2,7 +2,7 @@ Source: edge-proxy
 Section: utils
 Priority: optional
 Maintainer: Vasily Smirnov <vasilii.smirnov@globallogic.com>
-Build-Depends: debhelper (>=9), golang-go:native (>=2:1.9~), libc6
+Build-Depends: debhelper (>=9), golang-go:native (>=2:1.14~), golang-go:native (<<2:1.15~), libc6
 Standards-Version: 3.9.6
 Homepage: https://www.pelion.com
 

--- a/fog-core/deb/debian/control
+++ b/fog-core/deb/debian/control
@@ -2,7 +2,7 @@ Source: fog-core
 Section: utils
 Priority: optional
 Maintainer: Vasily Smirnov <vasilii.smirnov@globallogic.com>
-Build-Depends: debhelper (>=9), golang-go:native (>=2:1.9~), libc6
+Build-Depends: debhelper (>=9), golang-go:native (>=2:1.14~), golang-go:native (<<2:1.15~), libc6
 Standards-Version: 3.9.6
 Homepage: https://www.pelion.com
 

--- a/kubelet/deb/debian/control
+++ b/kubelet/deb/debian/control
@@ -2,7 +2,7 @@ Source: kubelet
 Section: utils
 Priority: optional
 Maintainer: Vasily Smirnov <vasilii.smirnov@globallogic.com>
-Build-Depends: debhelper (>=9), golang-go:native (>=2:1.9~), libc6
+Build-Depends: debhelper (>=9), golang-go:native (>=2:1.14~), golang-go:native (<<2:1.15~), libc6
 Standards-Version: 3.9.6
 Homepage: https://www.pelion.com
 

--- a/maestro-shell/deb/debian/control
+++ b/maestro-shell/deb/debian/control
@@ -2,7 +2,7 @@ Source: maestro-shell
 Section: utils
 Priority: optional
 Maintainer: Vasily Smirnov <vasilii.smirnov@globallogic.com>
-Build-Depends: debhelper (>=9), golang-go:native (>=2:1.7~), libc6
+Build-Depends: debhelper (>=9), golang-go:native (>=2:1.14~), golang-go:native (<<2:1.15~), libc6
 Standards-Version: 3.9.6
 Homepage: https://www.pelion.com
 

--- a/maestro/deb/debian/control
+++ b/maestro/deb/debian/control
@@ -2,7 +2,7 @@ Source: maestro
 Section: utils
 Priority: optional
 Maintainer: Vasily Smirnov <vasilii.smirnov@globallogic.com>
-Build-Depends: debhelper (>=9), golang-go:native (>=2:1.9~), python:native (>=2.7),
+Build-Depends: debhelper (>=9), golang-go:native (>=2:1.14~), golang-go:native (<<2:1.15~), python:native (>=2.7),
  autoconf (>=2.69), automake (>=1:1.15), libtool (>=2.4.6),
  libc6, libstdc++6, libunwind-dev
 Standards-Version: 3.9.6

--- a/rallypointwatchdogs/deb/debian/control
+++ b/rallypointwatchdogs/deb/debian/control
@@ -2,7 +2,7 @@ Source: rallypointwatchdogs
 Section: utils
 Priority: optional
 Maintainer: Vasily Smirnov <vasilii.smirnov@globallogic.com>
-Build-Depends: debhelper (>=9), golang-go:native (>=2:1.9~), libc6
+Build-Depends: debhelper (>=9), golang-go:native (>=2:1.14~), golang-go:native (<<2:1.15~), libc6
 Standards-Version: 3.9.6
 Homepage: https://www.pelion.com
 


### PR DESCRIPTION
In yocto and snap we depend on 1.14.4 so use that here also.