### PR TITLE
enable pe-utils and pe-nodejs in build-all

### DIFF
--- a/build-env/bin/pelion-build-all.sh
+++ b/build-env/bin/pelion-build-all.sh
@@ -18,8 +18,8 @@ PACKAGES=(
     'mbed-edge-core-devmode'
 #    'mbed-edge-examples'
 #    'mbed-fcc'
-#    'pe-nodejs'
-#    'pe-utils'
+    'pe-nodejs'
+    'pe-utils'
 #    'rallypointwatchdogs'
 )
 


### PR DESCRIPTION
the pe-utils project contains the identity scripts.