### PR TITLE
pelion-container-orchestration: add daemon.json

### DIFF
--- a/metapackages/pelion-container-orchestration/deb/debian/daemon.json
+++ b/metapackages/pelion-container-orchestration/deb/debian/daemon.json
@@ -1,0 +1,6 @@
+{
+    "debug":            false,
+    "log-level":        "error",
+    "storage-driver":   "aufs",
+    "max-concurrent-downloads": 1
+}

--- a/metapackages/pelion-container-orchestration/deb/debian/install
+++ b/metapackages/pelion-container-orchestration/deb/debian/install
@@ -1,0 +1,1 @@
+debian/daemon.json etc/docker


### PR DESCRIPTION
This file will be used when starting dockerd.  Dockerd will read
/etc/docker/daemon.json by default.