### PR TITLE
containernetworking-plugins depends on libc6 to build

### DIFF
--- a/golang-github-containernetworking-plugins/deb/debian/control
+++ b/golang-github-containernetworking-plugins/deb/debian/control
@@ -8,6 +8,7 @@ Uploaders: Jamie Bliss <jamie@ivyleav.es>,
            Dmitry Smirnov <onlyjob@debian.org>
 Build-Depends: debhelper-compat (= 12),
                dh-golang,
+               libc6,
                golang-any:native,
     golang-dbus-dev:native (>= 5.0.2~),
     golang-ginkgo-dev:native,


### PR DESCRIPTION
Explicitly include libc6 as a build dependency for containernetworking-plugins so it will build standalone.