### PR TITLE
Temporarily remove maestro logging config

### DIFF
--- a/maestro/deb/debian/pelion-base-config.yaml
+++ b/maestro/deb/debian/pelion-base-config.yaml
@@ -58,52 +58,6 @@ mdns:
       text:
         - "wwid={{ARCH_SERIAL_NUMBER}}"
       hostname: "{{ARCH_SERIAL_NUMBER}}"
-symphony:
-  # symphony system management APIs
-  # defaults to 10:
-  disable_sys_stats: true
-  sys_stats_count_threshold: 15 # send if you have 15 or more stats queued
-  sys_stats_time_threshold: 120000 # every 120 seconds send stuff, no matter what
-  #client_cert: "{{ARCH_CLIENT_CERT_PEM}}"
-  #client_key: "{{ARCH_CLIENT_KEY_PEM}}"
-  no_tls: true
-  host: "gateways.local"
-  url_logs: "http://gateways.local:8080/relay-logs/logs"
-  url_stats: "http://gateways.local:8080/relay-stats/stats_obj"
-  send_time_threshold: 120000 # set the send time threshold to 2 minutes
-  # port: "{{ARCH_RELAY_SERVICES_PORT}}"
-targets:
-  - file: "/var/log/pelion//maestro.log"
-    rotate:
-      max_files: 4
-      max_file_size: 10000000 # 10MB max file size
-      max_total_size: 42000000
-      rotate_on_start: true
-    delim: "\n"
-    format_time: "[%ld:%d] "
-    format_level: "<%s> "
-    format_tag: "{%s} "
-    format_origin: "(%s) "
-    filters:
-      - levels: warn
-        format_pre: "\u001B[33m" # yellow
-        format_post: "\u001B[39m"
-      - levels: error
-        format_pre: "\u001B[31m" # red
-        format_post: "\u001B[39m"
-  - name: "toCloud" # this is a special target for sending to the cloud. It must send as a JSON
-    format_time: '"timestamp":%ld%03d, '
-    format_level: '"level":"%s", '
-    format_tag: '"tag":"%s", '
-    format_origin: '"origin":"%s", '
-    format_pre_msg: '"text":"'
-    format_post: '"},'
-    flag_json_escape_strings: true
-    filters:
-      - levels: warn
-        format_pre: "{" # you will wrap this output with { "log": [ OUTPUT ] }
-      - levels: error
-        format_pre: "{" # you will wrap this output with { "log": [ OUTPUT ] }
 #   - file: "{{TMP_DIR}}/maestro.log"
 # - TTY: "console"
 #   rotate:


### PR DESCRIPTION
There are parsing errors in the logging section of maestro config that
only show up on arm64 architecture.  Removing this section for now so
progress can be made on other componenents.

Signed-off-by: Kyle Stein <kyle.stein@arm.com>