### PR TITLE
make edge-proxy go dependencies read-write

### DIFF
--- a/edge-proxy/deb/debian/auto_build
+++ b/edge-proxy/deb/debian/auto_build
@@ -19,3 +19,7 @@ cp -r "$@" "$pkgdir"/
 
 cd "$pkgdir"
 go build -buildmode=pie "$package"/cmd/edge-proxy
+
+# fix go's weird habit of checking out code read-only
+find "$GOPATH" -type d | xargs chmod +rwx
+find "$GOPATH" -type f | xargs chmod +rw


### PR DESCRIPTION
Golang has a weird habit of making it's dependencies read-only.  This
causes subsequent builds to fail because removing the previous buils
fails.  Make the go-workspace read-write so that subsequent builds don't
throw a permission denied error.