### PR TITLE
pe-nodejs source is arch-dependent

### DIFF
--- a/build-env/bin/pelion-build-all.sh
+++ b/build-env/bin/pelion-build-all.sh
@@ -106,7 +106,16 @@ pelion_parse_args "$@"
 if $PELION_PACKAGE_SOURCE; then
     for p in "${PACKAGES[@]}"; do
         echo "Generating source package of '$p'"
-        "$SCRIPT_DIR"/../../"$p"/deb/build.sh $PELION_BUILD_OPT --source
+        if [ "$p" == "pe-nodejs" ]; then
+            # pe-nodejs is just a debian package of pre-built # source.
+            # We need to pass the arch here so we know what binary tarball
+            # architecture to download.
+            for arch in "${PELION_ARCHS[@]}"; do
+                "$SCRIPT_DIR"/../../"$p"/deb/build.sh $PELION_BUILD_OPT --arch="$arch" --source
+            done
+        else
+            "$SCRIPT_DIR"/../../"$p"/deb/build.sh $PELION_BUILD_OPT --source
+        fi
     done
 fi
 


### PR DESCRIPTION
We're building pe-nodejs by downloading pre-built nodejs binaries and
packaging them for debian.  So, in the pe-nodejs the "source" is
a tarball of pre-built binaries for a particular architecture.  So, when
downloading the source you should specify the architecture.  If you
don't specify the arch, then when the build step happens, the downloaded
pre-built binary tarball arch and the build target arch might not match.