### PR TITLE
kubelet: move docker.io from Recommends to Depends

### DIFF
--- a/kubelet/deb/debian/control
+++ b/kubelet/deb/debian/control
@@ -9,7 +9,6 @@ Homepage: https://www.pelion.com
 Package: kubelet
 Architecture: any
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}, conntrack, ebtables, ethtool, iproute2, iptables (>=1.4.21), mount, socat, containernetworking-plugins, edge-proxy, pe-utils
-Recommends: docker.io | docker-ce
+Depends: ${misc:Depends}, ${shlibs:Depends}, conntrack, docker.io | docker-ce, ebtables, ethtool, iproute2, iptables (>=1.4.21), mount, socat, containernetworking-plugins, edge-proxy, pe-utils
 Description: talks to kubernetes service
  Repository https://github.com/armPelionEdge/edge-kubelet


### PR DESCRIPTION
our kubelet service depends explicitly on docker functionality