### PR TITLE
don't checkout source if the source folder already exists

### DIFF
--- a/build-env/inc/build-common.sh
+++ b/build-env/inc/build-common.sh
@@ -208,15 +208,15 @@ function pelion_source_preparation() {
 
         if [ ! -d "$PELION_SOURCE_DIR/$PACKAGE_COMPONENT_FILENAME" ]; then
             git clone $COMPONENT "$PELION_SOURCE_DIR/$PACKAGE_COMPONENT_FILENAME"
+            if [ ! ${PELION_PACKAGE_COMPONENTS[$COMPONENT]} ]; then
+                PELION_PACKAGE_COMPONENTS[$COMPONENT]=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            fi
+
+            cd "$PELION_SOURCE_DIR/$PACKAGE_COMPONENT_FILENAME"        && \
+            git remote update                                          && \
+            git checkout ${PELION_PACKAGE_COMPONENTS[$COMPONENT]}
         fi
 
-        if [ ! ${PELION_PACKAGE_COMPONENTS[$COMPONENT]} ]; then
-            PELION_PACKAGE_COMPONENTS[$COMPONENT]=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
-        fi
-
-        cd "$PELION_SOURCE_DIR/$PACKAGE_COMPONENT_FILENAME"        && \
-        git remote update                                          && \
-        git checkout ${PELION_PACKAGE_COMPONENTS[$COMPONENT]}
     done
 
     if [ -v PELION_PACKAGE_SOURCE_PREPARATION_CALLBACK ]; then


### PR DESCRIPTION
this allows developers to iterate from the build source folder
by making local changes and commits and rebuilding from that
without the changes being deleted and forced back to the SHA
contained in the <package>/deb/build.sh file.