### PR TITLE
maestro: Recommends resolvconf

### DIFF
--- a/maestro/deb/debian/control
+++ b/maestro/deb/debian/control
@@ -12,6 +12,7 @@ Package: maestro
 Architecture: any
 Multi-Arch: foreign
 Depends: ${misc:Depends}, ${shlibs:Depends}, libnss-myhostname, pe-utils, edge-proxy
+Recommends: resolvconf
 Description: system manager (logging, dhcp, cloud connector)
  Maestro is a replacement for a number of typical system utilities and
  management programs, while providing cloud-connected systems management.


### PR DESCRIPTION
resolvconf is used to integrate multiple writers of /etc/resolv.conf
which could be the case if maestro is configured to manage only a subset
of network interfaces on the system.