### PR TITLE
maestro: move db files to /var/lib/pelion/maestro

### DIFF
--- a/maestro/deb/debian/pelion-base-config.yaml
+++ b/maestro/deb/debian/pelion-base-config.yaml
@@ -2,7 +2,7 @@ unixLogSocket: /tmp/grease.socket
 sysLogSocket: /run/systemd/journal/syslog
 linuxKernelLog: false
 httpUnixSocket: /tmp/maestroapi.sock
-configDBPath: /var/lib/pelion/etc/maestroConfig.db
+configDBPath: /var/lib/pelion/maestro/maestroConfig.db
 imagePath: /tmp/maestro/images
 scratchPath: /tmp/maestro/scratch
 clientId: "{{ARCH_SERIAL_NUMBER}}"


### PR DESCRIPTION
this makes the path less confusing, less hard to find