### PR TITLE
bug fix: create var/lib/pelion/maestro directory during install

### DIFF
--- a/maestro/deb/debian/dirs
+++ b/maestro/deb/debian/dirs
@@ -1,2 +1,2 @@
-var/lib/pelion/etc
+var/lib/pelion/maestro
 var/log/pelion


### PR DESCRIPTION
the path the maestroConfigDB was changed but the debian package
installer wasn't updated at the same time.