### PR TITLE
fix golang-1.14 install breakage

### DIFF
--- a/build-env/docker/docker-debian-10-buster/Dockerfile.build
+++ b/build-env/docker/docker-debian-10-buster/Dockerfile.build
@@ -10,6 +10,8 @@ RUN usermod -aG sudo user
 
 COPY $LOCAL_SRC_PATH/sources.list.buster /etc/apt/sources.list
 COPY $LOCAL_SRC_PATH/preferences /etc/apt/preferences
+COPY $LOCAL_SRC_PATH/apt.conf.d/10-no-check-valid-until /etc/apt/apt.conf.d/10-no-check-valid-until
+
 
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armel

--- a/build-env/docker/docker-debian-10-buster/apt.conf.d/10-no-check-valid-until
+++ b/build-env/docker/docker-debian-10-buster/apt.conf.d/10-no-check-valid-until
@@ -1,0 +1,2 @@
+# ignore "valid until" timestamp so that installing from snapshot will work
+Acquire::Check-Valid-Until "0";

--- a/build-env/docker/docker-debian-10-buster/sources.list.buster
+++ b/build-env/docker/docker-debian-10-buster/sources.list.buster
@@ -8,4 +8,4 @@ deb http://deb.debian.org/debian buster-updates main
 deb [arch=amd64] http://deb.debian.org/debian buster-backports main
 
 # testing for golang
-deb http://deb.debian.org/debian testing main
+deb http://snapshot.debian.org/archive/debian/20200930T204132Z/ testing main


### PR DESCRIPTION
Debian testing(bullseye) rolled forward on us again.  We can't install
golang-1.14(>=1.14.4) because isn't no longer in curren testing.  Pin the
version of testing back to 2020-9-30 using snapshot.debian.org so that
we can install golang-1.14.