### PR TITLE
mbed-fcc: build for x86_64

### DIFF
--- a/mbed-fcc/deb/build.sh
+++ b/mbed-fcc/deb/build.sh
@@ -51,7 +51,7 @@ function pelion_mbed_fcc_origin_source_update_cb() {
     fi
 
     PYTHONUSERBASE="$PELION_TMP_BUILD_DIR/" \
-    $PYTHONCMD pal-platform/pal-platform.py -v deploy --target=Yocto_Generic_YoctoLinux_mbedtls generate
+    $PYTHONCMD pal-platform/pal-platform.py -v deploy --target=x86_x64_NativeLinux_mbedtls generate
 }
 
 pelion_main "$@"

--- a/mbed-fcc/deb/debian/install
+++ b/mbed-fcc/deb/debian/install
@@ -1,1 +1,1 @@
-__Yocto_Generic_YoctoLinux_mbedtls/Release/factory-configurator-client-example.elf usr/bin
+__x86_x64_NativeLinux_mbedtls/Release/factory-configurator-client-example.elf usr/bin

--- a/mbed-fcc/deb/debian/rules
+++ b/mbed-fcc/deb/debian/rules
@@ -7,20 +7,22 @@ export CC=${DEB_HOST_GNU_TYPE}-gcc
 export CXX=${DEB_HOST_GNU_TYPE}-g++
 export PKG_CONFIG=${DEB_HOST_GNU_TYPE}-pkg-config
 
+export FCC_TARGET=x86_x64_NativeLinux_mbedtls
+
 %:
-	dh $@ --buildsystem=cmake --builddirectory=__Yocto_Generic_YoctoLinux_mbedtls/
+	dh $@ --buildsystem=cmake --builddirectory=__${FCC_TARGET}/
 
 override_dh_auto_clean:
-	cd __Yocto_Generic_YoctoLinux_mbedtls/ && \
+	cd __${FCC_TARGET}/ && \
 	find ! \( -name 'CMakeLists.txt' -o -name 'autogen.cmake' \) -type f -exec rm -f {} \; && \
 	find -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
 
 override_dh_auto_configure:
-	cd __Yocto_Generic_YoctoLinux_mbedtls/ && \
-	cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE="Release" -DCMAKE_TOOLCHAIN_FILE=../pal-platform/Toolchain/POKY-GLIBC/POKY-GLIBC.cmake -DEXTARNAL_DEFINE_FILE=../linux-config.cmake
+	cd __${FCC_TARGET}/ && \
+	cmake -G 'Unix Makefiles' -DCMAKE_BUILD_TYPE="Release" -DCMAKE_TOOLCHAIN_FILE=../pal-platform/Toolchain/GCC/GCC.cmake -DEXTERNAL_DEFINE_FILE=./../linux-config.cmake
 
 override_dh_auto_build:
-	cd __Yocto_Generic_YoctoLinux_mbedtls/ && \
+	cd __${FCC_TARGET}/ && \
 	make factory-configurator-client-example.elf
 
 override_dh_auto_install:


### PR DESCRIPTION
building for x86_64 fixes the following error when run in a debian
environment:

In single-partition mode.
Creating path ./pal
Factory flow begins...
Storage is erased
Generating random from /dev/hwrng, this can take a long time!
[ERR ][esfs]: esfs_create() - pal_osGetDeviceKey() failed with pal status 0xfffffffb
[ERR ][fcc ]: storage_pelion_sst.c:1156:storage_file_create:Failed creating file (esfs_status 4)
[ERR ][fcc ]: storage_pelion_sst.c:998:storage_file_write:<=== Failed to create new file
[ERR ][fcc ]: storage_pelion_sst.c:355:storage_item_store_impl:<=== Failed writing file to storage
[ERR ][fcc ]: storage_common.c:118:storage_item_store:<=== storage_data_write_impl failed

[ERR ][fcc ]: key_config_manager.c:138:kcm_item_store:<=== Failed during storage_data_write
[ERR ][fcc ]: fcc_bundle_key_utils.c:109:fcc_bundle_process_keys_cb:<=== Failed to store key param
[ERR ][fcc ]: fcc_bundle_common_utils.c:255:fcc_bundle_process_maps_in_arr:<=== Failed parsing map
[ERR ][fcc ]: fcc_bundle_handler.c:376:fcc_bundle_handler:fcc_bundle_process_keys failed