### PR TITLE
pelion-protocol-engine: mbed-edge-core-devmode is the default

### DIFF
--- a/metapackages/pelion-protocol-engine/deb/debian/control
+++ b/metapackages/pelion-protocol-engine/deb/debian/control
@@ -8,6 +8,6 @@ Homepage: https://www.pelion.com
 
 Package: pelion-protocol-engine
 Architecture: all
-Depends: devicedb, global-node-modules, mbed-edge-examples, mbed-edge-core
+Depends: devicedb, global-node-modules, mbed-edge-examples, mbed-edge-core-devmode | mbed-edge-core
 Description: protocol-engine package group
  Combine devicedb, global-node-modules mbed-edge-examples, mbed-edge-core


### PR DESCRIPTION
Make mbed-edge-core-devmode the default edge-core for
pelion-protocol-engine just like it is for the other packages.