### PR TITLE
edge-core: disable firmware update

### DIFF
--- a/mbed-edge-core-devmode/deb/debian/rules
+++ b/mbed-edge-core-devmode/deb/debian/rules
@@ -7,7 +7,7 @@
 	dh $@ --builddirectory=build/ --with systemd
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DDEVELOPER_MODE=ON -DFIRMWARE_UPDATE=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTRACE_LEVEL=WARN -DMBED_CLOUD_DEV_UPDATE_ID=ON
+	dh_auto_configure -- -DDEVELOPER_MODE=ON -DFIRMWARE_UPDATE=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTRACE_LEVEL=WARN -DMBED_CLOUD_DEV_UPDATE_ID=ON
 
 override_dh_clean:
 	rm -rf build/*

--- a/mbed-edge-core/deb/debian/rules
+++ b/mbed-edge-core/deb/debian/rules
@@ -7,7 +7,7 @@
 	dh $@ --builddirectory=build/ --with systemd
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DFACTORY_MODE=ON -DFIRMWARE_UPDATE=ON
+	dh_auto_configure -- -DFACTORY_MODE=ON -DFIRMWARE_UPDATE=OFF
 
 override_dh_clean:
 	rm -rf build/*


### PR DESCRIPTION
firmware update is not currently working and throws errors in the
log on startup, so let's disable it until it can be fixed.