### PR TITLE
Fix copied file permissions

### DIFF
--- a/build-env/docker/docker-debian-10-buster/Dockerfile.build
+++ b/build-env/docker/docker-debian-10-buster/Dockerfile.build
@@ -12,6 +12,7 @@ RUN echo "APT::Acquire::Retries \"3\";" > /etc/apt/apt.conf.d/80-retries
 COPY $LOCAL_SRC_PATH/sources.list.buster /etc/apt/sources.list
 COPY $LOCAL_SRC_PATH/preferences /etc/apt/preferences
 COPY $LOCAL_SRC_PATH/apt.conf.d/10-no-check-valid-until /etc/apt/apt.conf.d/10-no-check-valid-until
+RUN chmod 644 /etc/apt/sources.list /etc/apt/preferences /etc/apt/apt.conf.d/10-no-check-valid-until
 RUN mkdir -p /opt/apt-repo/pe-dependencies && echo -n| gzip >/opt/apt-repo/pe-dependencies/Packages.gz && find /opt && apt-get update
 
 RUN dpkg --add-architecture arm64

--- a/build-env/docker/docker-debian-9-stretch/Dockerfile.build
+++ b/build-env/docker/docker-debian-9-stretch/Dockerfile.build
@@ -10,6 +10,7 @@ RUN usermod -aG sudo user
 
 COPY $LOCAL_SRC_PATH/sources.list.stretch /etc/apt/sources.list
 COPY $LOCAL_SRC_PATH/preferences /etc/apt/preferences
+RUN chmod 644 /etc/apt/sources.list /etc/apt/preferences
 
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armel

--- a/build-env/docker/docker-ubuntu-16-xenial/Dockerfile
+++ b/build-env/docker/docker-ubuntu-16-xenial/Dockerfile
@@ -9,6 +9,8 @@ RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
 
 COPY $LOCAL_SRC_PATH/sources.list.xenial /etc/apt/sources.list
+RUN chmod 644 /etc/apt/sources.list
+
 
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armhf

--- a/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
@@ -9,6 +9,7 @@ RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
 
 COPY $LOCAL_SRC_PATH/sources.list.bionic /etc/apt/sources.list
+RUN chmod 644 /etc/apt/sources.list
 RUN mkdir -p /opt/apt-repo/pe-dependencies && echo -n| gzip >/opt/apt-repo/pe-dependencies/Packages.gz && find /opt && apt-get update
 
 RUN dpkg --add-architecture arm64

--- a/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
@@ -10,6 +10,7 @@ RUN usermod -aG sudo user
 
 RUN echo "APT::Acquire::Retries \"3\";" > /etc/apt/apt.conf.d/80-retries
 COPY $LOCAL_SRC_PATH/sources.list.focal /etc/apt/sources.list
+RUN chmod 644 /etc/apt/sources.list
 RUN mkdir -p /opt/apt-repo/pe-dependencies && echo -n| gzip >/opt/apt-repo/pe-dependencies/Packages.gz && find /opt && apt-get update
 
 RUN dpkg --add-architecture arm64


### PR DESCRIPTION
We can't assume the host system file permissions(ex: 644).  The host
system user could have different default permissions(ex: 640) for
security.  So, explicitly set the permissions on any files copied during
the docker image build.

Without this fix, a host system with default 640 file permissions will
fail this: `./build-env/bin/docker-debian-buster-create.sh && ./build-env/bin/docker-run.sh ${PELION_DOCKER_PREFIX}pelion-buster-source ./golang-providers/golang-virtual/deb/build.sh --install --arch=amd64`

...because `apt-get -y download` running as non-root can't read
`sources.list`.