### PR TITLE
Use ssh-agent if available instead of mounting $HOME/.ssh

### DIFF
--- a/build-env/bin/docker-run.sh
+++ b/build-env/bin/docker-run.sh
@@ -7,8 +7,14 @@ APT_REPO="$ROOT_DIR"/build/apt/$DOCKER_DIST
 echo "Using APT repo dir: " $APT_REPO
 mkdir -p $APT_REPO
 
+if [ -n "$SSH_AUTH_SOCK" ]; then
+	SSH_ARGS="-v $SSH_AUTH_SOCK:/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent"
+else
+	SSH_ARGS="-v \"$HOME/.ssh\":/home/user/.ssh"
+fi
+
 docker run -it \
-    -v "$HOME/.ssh":/home/user/.ssh \
+    $SSH_ARGS \
     -v "$HOME":/mnt/home \
     -v "$ROOT_DIR":/pelion-build \
     -v "$APT_REPO":/opt/apt-repo \


### PR DESCRIPTION
Some users like to keep their SSH identity in an ssh agent instead of
passphraseless on disk.  If an SSH agent is available, use that for ssh
authentication instead of volume mounting $HOME/.ssh.