### PR TITLE
Fix addgroup failure

### DIFF
--- a/build-env/docker/docker-debian-10-buster/Dockerfile.build
+++ b/build-env/docker/docker-debian-10-buster/Dockerfile.build
@@ -4,7 +4,7 @@ ARG USER_ID
 ARG GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-debian-10-buster
 
-RUN addgroup --gid $GROUP_ID user
+RUN groupadd -o --gid $GROUP_ID user
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
 

--- a/build-env/docker/docker-debian-9-stretch/Dockerfile.build
+++ b/build-env/docker/docker-debian-9-stretch/Dockerfile.build
@@ -4,7 +4,7 @@ ARG USER_ID
 ARG GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-debian-9-stretch
 
-RUN addgroup --gid $GROUP_ID user
+RUN groupadd -o --gid $GROUP_ID user
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
 

--- a/build-env/docker/docker-ubuntu-16-xenial/Dockerfile
+++ b/build-env/docker/docker-ubuntu-16-xenial/Dockerfile
@@ -4,7 +4,7 @@ ARG USER_ID
 ARG GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-ubuntu-16-xenial
 
-RUN addgroup --gid $GROUP_ID user
+RUN groupadd -o --gid $GROUP_ID user
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
 

--- a/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
@@ -4,7 +4,7 @@ ARG USER_ID
 ARG GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-ubuntu-18-bionic
 
-RUN addgroup --gid $GROUP_ID user
+RUN groupadd -o --gid $GROUP_ID user
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
 

--- a/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
@@ -4,7 +4,7 @@ ARG USER_ID
 ARG GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-ubuntu-20-focal
 
-RUN addgroup --gid $GROUP_ID user
+RUN groupadd -o --gid $GROUP_ID user
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
 


### PR DESCRIPTION
When the given GROUP_ID is too low, it can clash with builtin group
ids, causing the entire build to fail.

This commit falls back to the first available group id if the initially
attempted gid already exists.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>