### PR TITLE
remove tini as a dependency

### DIFF
--- a/metapackages/pelion-container-orchestration/deb/debian/control
+++ b/metapackages/pelion-container-orchestration/deb/debian/control
@@ -8,6 +8,6 @@ Homepage: https://www.pelion.com
 
 Package: pelion-container-orchestration
 Architecture: all
-Depends: kubelet, tini
+Depends: kubelet
 Description: container-orchestration package group
  Combine kubelet


### PR DESCRIPTION
It looks like we brought tini over from the snap package as a
dependency.  tini is included in docker since docker 1.13[1].  I'm not
sure why we would need it installed unless we are creating containers.
Since we're not, I'm removing it as a dependency.

[1] https://github.com/krallin/tini#using-tini