### PR TITLE
fix docker build on Ubuntu/Debian host

### DIFF
--- a/build-env/inc/build-common.sh
+++ b/build-env/inc/build-common.sh
@@ -25,7 +25,7 @@ source $SCRIPT_DIR/env-common.sh
 
 function update_pelion_variables
 {
-    PELION_PACKAGE_VERSION_CODENAME=${PELION_PACKAGE_VERSION_CODENAME:-$DOCKER_DIST}
+    PELION_PACKAGE_VERSION_CODENAME=${DOCKER_DIST:-$PELION_PACKAGE_VERSION_CODENAME}
 
     if [ -z "$PELION_PACKAGE_VERSION_CODENAME" ]; then
         echo "ERROR: unable to get build codename"


### PR DESCRIPTION
Use correct resolution order of target system codename when --docker switch is used on Debian or Ubuntu host.