### PR TITLE
Fix Mac build authentication

### DIFF
--- a/build-env/docker/common/.bash_aliases
+++ b/build-env/docker/common/.bash_aliases
@@ -1,3 +1,7 @@
 alias cdr="cd /pelion-build"
 alias cdh="cd /mnt/home"
+alias v="ls -la"
 
+# Docker for Mac does not correctly map the socket permissions and owner
+# making it unusable in the default state except by root
+[ -n "$SSH_AUTH_SOCK" ] && sudo chown user $SSH_AUTH_SOCK


### PR DESCRIPTION
Docker for Mac has a particular, non-standard way to forward the ssh
agent socket, by using a hard coded magic path.
This commit implements that, and also adds a fix so non-root users can
use the socket as well.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>