### PR TITLE
README: document single-package build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,16 @@ $ ./build-env/bin/docker-debian-buster-create.sh # Debian 10
 $ ./build-env/bin/docker-run.sh pelion-buster-source
 ```
 
-
 ## Building a single package
+
+Dependency packages must be built prior to building a single package.
+```
+$ ./build-env/bin/pelion-build-all.sh --deps --install --docker=<dist>
+```
+or
+```
+$ ./build-env/bin/docker-run.sh pelion-<dist>-source ./build-env/bin/pelion-build-all.sh --deps --install
+```
 
 The build scripts provide help information, for example:
 


### PR DESCRIPTION
Add a note that informs the user that package dependencies must
be built first before attempting to build any single package.

Fixes the following issue: https://github.com/PelionIoT/linux-pelion-edge/issues/88