### PR TITLE
Revert "Fixing Kubelet Version"

### DIFF
--- a/kubelet/deb/debian/auto_build
+++ b/kubelet/deb/debian/auto_build
@@ -13,13 +13,10 @@ eval "$(debian/goflags.guess $DEB_HOST_ARCH)"
 
 package=k8s.io/kubernetes
 packagedir=$GOPATH/src/$package
-origpath="$(pwd)"
 
 rm -rf "$GOPATH"
 set -- *
 mkdir -p "$packagedir"
 cp -r "$@" "$packagedir"/
 
-cd "$packagedir"/hack/make-rules
-KUBE_VERBOSE=0 ./build.sh "$package"/cmd/kubelet
-cp "$packagedir"/_output/local/go/bin/kubelet "$origpath"/
+go build -buildmode=pie "$package"/cmd/kubelet


### PR DESCRIPTION
This reverts commit 28785a6859fa4d9b375431359305573c86e831df.

This commit breaks the build so back it out for now.