### PR TITLE
Fix systemd service startup and install dependencies

### DIFF
--- a/devicedb/deb/debian/devicedb.service
+++ b/devicedb/deb/debian/devicedb.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=DeviceDB: Remote database manager for Maestro
-After=maestro edge-proxy
+Requires=edge-proxy.service
+After=maestro.service edge-proxy.service
 
 [Service]
 Restart=always
@@ -10,4 +11,4 @@ ExecStart=/usr/bin/devicedb start -conf /etc/pelion/devicedb.yaml
 Type=simple
 
 [Install]
-RequiredBy=network.target
+WantedBy=multi-user.target

--- a/edge-proxy/deb/debian/edge-proxy.service
+++ b/edge-proxy/deb/debian/edge-proxy.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Edge Proxy
+Requires=wait-for-pelion-identity.service
 After=wait-for-pelion-identity.service
 
 [Service]
@@ -8,4 +9,4 @@ RestartSec=5s
 ExecStart=/usr/bin/launch-edge-proxy.sh
 
 [Install]
-RequiredBy=network.target
+WantedBy=multi-user.target

--- a/global-node-modules/deb/debian/pelion-relay-term.service
+++ b/global-node-modules/deb/debian/pelion-relay-term.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=relay terminal for remote terminals in pelion cloud
+Requires=maestro.service
+After=maestro.service
 
 [Service]
 Restart=always
@@ -8,4 +10,4 @@ Environment=NODE_PATH=/usr/lib/pelion/devicejs-core-modules/node_modules
 ExecStart=/usr/lib/pelion/bin/node /usr/lib/pelion/wigwag-core-modules/relay-term/src/index.js start /etc/pelion/relay-term-config.json
 
 [Install]
-WantedBy=network.target
+WantedBy=multi-user.target

--- a/kubelet/deb/debian/kubelet.service
+++ b/kubelet/deb/debian/kubelet.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Kubelet
+Requires=edge.proxy.service
 After=edge-proxy.service
 
 [Service]
@@ -8,4 +9,4 @@ RestartSec=5s
 ExecStart=/usr/bin/launch-kubelet.sh
 
 [Install]
-RequiredBy=network.target
+WantedBy=multi-user.target

--- a/maestro/deb/debian/maestro.service
+++ b/maestro/deb/debian/maestro.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Maestro: Network, Config, DeviceJS manager
-After=wait-for-pelion-identity.service edge-proxy.service
+Requires=edge-proxy.service
+After=edge-proxy.service
 
 [Service]
 Restart=always
@@ -10,4 +11,4 @@ ExecStart=/usr/bin/maestro -config /etc/pelion/pelion-base-config.yaml
 StandardOutput=tty
 
 [Install]
-RequiredBy=network.target
+WantedBy=multi-user.target

--- a/mbed-edge-core-devmode/deb/debian/edge-core.service
+++ b/mbed-edge-core-devmode/deb/debian/edge-core.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Edge Core
-After=systemd-networkd-wait-online.service
+After=network-online.target
 
 [Service]
 Restart=always
@@ -9,4 +9,4 @@ WorkingDirectory=/var/lib/pelion/mbed
 ExecStart=/usr/bin/edge-core --http-port 9101
 
 [Install]
-RequiredBy=network.target
+WantedBy=multi-user.target

--- a/mbed-edge-core/deb/debian/edge-core.service
+++ b/mbed-edge-core/deb/debian/edge-core.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Edge Core
-After=systemd-networkd-wait-online.service
+After=network-online.target
 
 [Service]
 Restart=always
@@ -9,4 +9,4 @@ WorkingDirectory=/var/lib/pelion/mbed
 ExecStart=/usr/bin/launch-edge-core.sh
 
 [Install]
-RequiredBy=network.target
+WantedBy=multi-user.target

--- a/mbed-fcc/deb/debian/mbed-fcc.service
+++ b/mbed-fcc/deb/debian/mbed-fcc.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Mbed FCC
-After=systemd-networkd-wait-online.service
+After=network-online.target
 
 [Service]
 ExecStart=/usr/bin/launch-fcc.sh
 
 [Install]
-RequiredBy=network.target
+WantedBy=multi-user.target

--- a/pe-utils/deb/debian/wait-for-pelion-identity.service
+++ b/pe-utils/deb/debian/wait-for-pelion-identity.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Wait for a connection to Pelion and create cridentials
+Requires=edge-core.service
 After=edge-core.service
 
 [Service]
@@ -9,4 +10,4 @@ RemainAfterExit=true
 ExecStart=/bin/bash -c "PATH=/usr/lib/pelion/developer_identity:$PATH exec /usr/bin/generate-identity.sh 9101 /var/lib/pelion/edge_gw_config"
 
 [Install]
-WantedBy=network.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Instead of RequiredBy=network.target which blocks network.target until
the services have started(not what we want), change all `Install`
directives to WantedBy=multi-user.target.  This is pretty standard for
Debian/Ubuntu/Redhat as it represents the old sysvinit runlevel 3[1].

Also change the startup dependencies ensure that services we depend on
are marked as such(`Requires`) and make sure we wait until our
dependencies have started(`After`)[2].

[1] https://unix.stackexchange.com/a/506374/333250
[2] https://serverfault.com/a/812589