### PR TITLE
fix relay-term startup

### DIFF
--- a/maestro/deb/debian/template/relayTerm.template.json
+++ b/maestro/deb/debian/template/relayTerm.template.json
@@ -1,6 +1,6 @@
 {
-	"cloud": "{{ARCH_GW_SERVICES_URL}}/relay-term",
+	"cloud": "http://gateways.local:8080/relay-term",
 	"noValidate": true,
-	"certificate": "{{SSL_CERTS_PATH}}/client.cert.pem",
-	"key": "{{SSL_CERTS_PATH}}/client.key.pem"
+	"certificate": "",
+	"key": ""
 }


### PR DESCRIPTION
relay-term was misconfigured to use client certificates, but
instead the service should be configured to connect via
edge-proxy.service which manages client-side certificates on our
behalf.