### PR TITLE
Revert "edge-core: disable firmware update"

### DIFF
--- a/mbed-edge-core-devmode/deb/debian/rules
+++ b/mbed-edge-core-devmode/deb/debian/rules
@@ -7,7 +7,7 @@
 	dh $@ --builddirectory=build/ --with systemd
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DDEVELOPER_MODE=ON -DFIRMWARE_UPDATE=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTRACE_LEVEL=WARN -DMBED_CLOUD_DEV_UPDATE_ID=ON
+	dh_auto_configure -- -DDEVELOPER_MODE=ON -DFIRMWARE_UPDATE=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTRACE_LEVEL=WARN -DMBED_CLOUD_DEV_UPDATE_ID=ON
 
 override_dh_clean:
 	rm -rf build/*

--- a/mbed-edge-core/deb/debian/rules
+++ b/mbed-edge-core/deb/debian/rules
@@ -7,7 +7,7 @@
 	dh $@ --builddirectory=build/ --with systemd
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DFACTORY_MODE=ON -DFIRMWARE_UPDATE=OFF
+	dh_auto_configure -- -DFACTORY_MODE=ON -DFIRMWARE_UPDATE=ON
 
 override_dh_clean:
 	rm -rf build/*


### PR DESCRIPTION
This reverts commit f29287db4a230bec3c5e925c8d2a8203da348225.

We need firmware update enabled so that edge-core will parse
update_default_resources.c for the device ID and class ID so that Edge
features will be available in the cloud(remote terminal in portal, etc)