### PR TITLE
removed kubelets daemon.json file from deb construction

### DIFF
--- a/kubelet/deb/debian/daemon.json
+++ b/kubelet/deb/debian/daemon.json
@@ -1,5 +1,0 @@
-{
-    "debug":            false,
-    "log-level":        "error",
-    "max-concurrent-downloads": 1
-}

--- a/kubelet/deb/debian/install
+++ b/kubelet/deb/debian/install
@@ -2,4 +2,3 @@ kubelet usr/bin
 debian/kubeconfig /etc/pelion
 debian/launch-edgenet.sh usr/bin
 debian/launch-kubelet.sh usr/bin
-debian/daemon.json etc/docker


### PR DESCRIPTION
It's no longer needed and interferes with NVidias L4T configuration

    Background:
    
    NVidia's "JetPack" L4T image contains a specialized version of Docker
    which is integrated with the underlying Cuda cores within the NVidia
    architecture. As a result, the L4T image contains /etc/docker/daemon.json
    which is a filed owned by the Nvidia-managed docker deb package - and
    daemon.json file contains specific Nvidia configuration parameters
    needed by Docker for the underlying integration. Hence, our kubelet
    deb package, when installed on L4T instances, would collide with this
    specific file... being "owned" by two separate packages.
    
    FYI, docker-pelion-edge uses its own daemon.json file in leu of this
    one in the kubelet deb package.
