### PR TITLE
kubelet.service update

### DIFF
--- a/kubelet/deb/debian/kubelet.service
+++ b/kubelet/deb/debian/kubelet.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Kubelet
-Requires=edge.proxy.service
+Requires=edge-proxy.service
 After=edge-proxy.service
 
 [Service]


### PR DESCRIPTION
Right now kubelet is failing on master with following status
`sudo systemctl start kubelet.service 
Failed to start kubelet.service: Unit edge.proxy.service not found.`

Updating kubelet.service followed by a restart helped me to get kubelet working
JIRA: [PELEDGE19-4189](https://armiot.atlassian.net/browse/PELEDGE19-4189)