### PR TITLE
maestro: remove identity.json platform reader

### DIFF
--- a/maestro/deb/debian/pelion-base-config.yaml
+++ b/maestro/deb/debian/pelion-base-config.yaml
@@ -8,10 +8,6 @@ scratchPath: /tmp/maestro/scratch
 clientId: "{{ARCH_SERIAL_NUMBER}}"
 network:
   disable: true
-platform_readers:
-  - platform: "fsonly"
-    params:
-      identityPath: "/var/lib/pelion/edge_gw_config/identity.json"
 var_defs:
   - key: "TMP_DIR"
     value: "/tmp"


### PR DESCRIPTION
it is not necessary for maestro to read identity.json on
startup since it is not configured to create self-signed certs.