### PR TITLE
transition github.com urls from ssh to https

### DIFF
--- a/devicedb/deb/build.sh
+++ b/devicedb/deb/build.sh
@@ -5,7 +5,7 @@ PELION_PACKAGE_NAME="devicedb"
 PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["git@github.com:armPelionEdge/devicedb.git"]="d24df289ab24a035ebf64d2ed27a2d531a2319da")
+    ["https://github.com/armPelionEdge/devicedb.git"]="d24df289ab24a035ebf64d2ed27a2d531a2319da")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 

--- a/edge-proxy/deb/build.sh
+++ b/edge-proxy/deb/build.sh
@@ -5,7 +5,7 @@ PELION_PACKAGE_NAME="edge-proxy"
 PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["git@github.com:armPelionEdge/edge-proxy.git"]="7e70a2f1cc32e7cd732d5abfa41857da017abb24")
+    ["https://github.com/armPelionEdge/edge-proxy.git"]="7e70a2f1cc32e7cd732d5abfa41857da017abb24")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 

--- a/golang-github-containernetworking-plugins/deb/build.sh
+++ b/golang-github-containernetworking-plugins/deb/build.sh
@@ -7,7 +7,7 @@ PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 PELION_PACKAGE_BINARY_NAME="containernetworking-plugins"
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["git@github.com:containernetworking/plugins.git"]="v0.8.4")
+    ["https://github.com/containernetworking/plugins.git"]="v0.8.4")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 

--- a/kubelet/deb/build.sh
+++ b/kubelet/deb/build.sh
@@ -5,7 +5,7 @@ PELION_PACKAGE_NAME="kubelet"
 PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["git@github.com:armPelionEdge/edge-kubelet.git"]="83b266ae6939012883611d6dbda745f2490a67c4")
+    ["https://github.com/armPelionEdge/edge-kubelet.git"]="83b266ae6939012883611d6dbda745f2490a67c4")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 

--- a/maestro-shell/deb/build.sh
+++ b/maestro-shell/deb/build.sh
@@ -8,7 +8,7 @@ PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 export PACKAGE_BRANCH="2c90fbe2552c58ec5121b75a08718be6ebe5a791"
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["git@github.com:armPelionEdge/maestro-shell.git"]="$PACKAGE_BRANCH")
+    ["https://github.com/armPelionEdge/maestro-shell.git"]="$PACKAGE_BRANCH")
 
 PELION_PACKAGE_PRE_BUILD_CALLBACK=configure_python
 

--- a/maestro/deb/build.sh
+++ b/maestro/deb/build.sh
@@ -5,7 +5,7 @@ PELION_PACKAGE_NAME="maestro"
 PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["git@github.com:armPelionEdge/maestro.git"]="a0adef8c579db2eaa15f08d1813eef417850f7d6")
+    ["https://github.com/armPelionEdge/maestro.git"]="a0adef8c579db2eaa15f08d1813eef417850f7d6")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 

--- a/rallypointwatchdogs/deb/build.sh
+++ b/rallypointwatchdogs/deb/build.sh
@@ -5,7 +5,7 @@ PELION_PACKAGE_NAME="rallypointwatchdogs"
 PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["git@github.com:armPelionEdge/rallypointwatchdogs.git"]="54ee3bd50b063425606ad76aefad4167780d8760")
+    ["https://github.com/armPelionEdge/rallypointwatchdogs.git"]="54ee3bd50b063425606ad76aefad4167780d8760")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 


### PR DESCRIPTION
Since all of these repos are public now, let's not require ssh to avoid
the hassle of ssh public key-based auth