### PR TITLE
Fixing HTTPS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ For example:
 $ ./build-env/bin/docker-run.sh pelion-bionic-source
 ```
 
-The script mounts the user `.ssh` directory  to share git ssh keys.  The root of
-this repo is mounted to `/pelion-build`.
+The root of this repo is mounted to `/pelion-build`.
 
 Please note that `docker-run.sh` script does not use `PELION_DOCKER_PREFIX`.
 

--- a/global-node-modules/deb/build.sh
+++ b/global-node-modules/deb/build.sh
@@ -9,7 +9,7 @@ PELION_PACKAGE_SUPPORTED_ARCH=(amd64 arm64 armhf)
 PELION_PACKAGE_ORIGIN_SOURCE_UPDATE_CALLBACK=pelion_global_node_modules_source_update_cb
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["https://github.com/armPelionEdge/edge-node-modules.git"]="a70efd3dd4c35904937c2707403313cc3023b025"
+    ["https://github.com/armPelionEdge/edge-node-modules.git"]="1ea6080fcc17e588c4f53c86a6c2b2bd7df3f05c"
     ["https://github.com/armPelionEdge/devjs-production-tools.git"]="master")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
@@ -23,7 +23,7 @@ function pelion_global_node_modules_source_update_cb() {
 
     cd "$PELION_TMP_BUILD_DIR/$PELION_PACKAGE_FOLDER_NAME/edge-node-modules"
 
-    node ../devjs-production-tools/consolidator.js -O overrides.json -d grease-log -d dhclient -d WWSupportTunnel ./*/
+    node ../devjs-production-tools/consolidator.js -o -O overrides.json -d grease-log -d dhclient -d WWSupportTunnel ./*/
     sed -i '/isc-dhclient/d' ./package.json
     sed -i '/node-hotplug/d' ./package.json
 


### PR DESCRIPTION
Fixing HTTPS build

Global-node-modules had to be updated to the latest version to build
with HTTPS only build.

See: PelionIoT/edge-node-modules@1ea6080

Likewise the consolidator.js script called during the build had to
use the overwrite flag to work with the new node-module updates.