### PR TITLE
Ensure apt repo directory permissions are correct

### DIFF
--- a/build-env/bin/docker-run.sh
+++ b/build-env/bin/docker-run.sh
@@ -5,7 +5,7 @@ ROOT_DIR=$(cd "`dirname \"$0\"`"/../.. && pwd)
 DOCKER_DIST=$(echo $1 | cut -d- -f2)
 APT_REPO="$ROOT_DIR"/build/apt/$DOCKER_DIST
 echo "Using APT repo dir: " $APT_REPO
-mkdir -p $APT_REPO
+mkdir -p -m 755 $APT_REPO
 
 if [ -n "$SSH_AUTH_SOCK" ]; then
 	# Docker for Mac requires a magic string instead of the value of SSH_AUTH_SOCK - see https://github.com/docker/for-mac/issues/410#issuecomment-537127831


### PR DESCRIPTION
When creating directories as the host user, we can't assume that the
user hasn't changed their umask to be more restrictive.  So we should
explicitly set the umask to ensure it's consistent.  Example: Without
this the build can fail if the user's umask is 026