### PR TITLE
Fix PELION_DOCKER_PREFIX instructions to not suggest using dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ of the distribution.  For example, to build for Debian 10, use `debian-buster`.
 To add prefix to docker images export `PELION_DOCKER_PREFIX`  variable  in  your
 shell with your prefix:
 ```
-export PELION_DOCKER_PREFIX=${USER}-
+export PELION_DOCKER_PREFIX=${USER}/
 ```
 
 The system is configured to use `sudo` without a password.


### PR DESCRIPTION
[PELION_DOCKER_PREFIX cannot include a dash](https://github.com/PelionIoT/distro-pelion-edge/issues/101) so don't suggest using a dash in the instructions.