### PR TITLE
Disable real-time scheduling in mbed-fcc

### DIFF
--- a/mbed-fcc/deb/debian/patches/0003-Add-support-for-OS-s-that-do-not-have-RT-scheduling-.patch
+++ b/mbed-fcc/deb/debian/patches/0003-Add-support-for-OS-s-that-do-not-have-RT-scheduling-.patch
@@ -1,0 +1,66 @@
+From dbe7fec3da32fef1ad1ae944b7c0f74528fe7996 Mon Sep 17 00:00:00 2001
+From: Michael Ray <michael.ray@arm.com>
+Date: Tue, 23 Mar 2021 15:28:48 -0500
+Subject: [PATCH] Add support for OS's that do not have RT scheduling support
+
+For any OS that doesn't have real-time scheduling support, threading priority
+and policy settings should not be set.
+
+Create a macro that turns on or off these settings.
+Macro is enabled by default, but can be turned off in the config file for Linux
+---
+ mbed-cloud-client/mbed-client-pal/Configs/pal_config/Linux/Linux_default.h              | 4 ++++
+ .../Source/Port/Reference-Impl/OS_Specific/Linux/RTOS/pal_plat_rtos.c | 4 ++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/mbed-cloud-client/mbed-client-pal/Configs/pal_config/Linux/Linux_default.h b/mbed-cloud-client/mbed-client-pal/Configs/pal_config/Linux/Linux_default.h
+index 818f7df..f3d3505 100644
+--- a/mbed-cloud-client/mbed-client-pal/Configs/pal_config/Linux/Linux_default.h
++++ b/mbed-cloud-client/mbed-client-pal/Configs/pal_config/Linux/Linux_default.h
+@@ -192,6 +192,10 @@
+     #define PAL_USE_FILESYSTEM 1
+ #endif
+ 
++// Enable real-time scheduling thread settings
++#ifndef REAL_TIME_SCHEDULING_ENABLED
++    #define REAL_TIME_SCHEDULING_ENABLED 1
++#endif
+ 
+ // Sanity check for defined stack sizes
+ #if (PAL_NET_TEST_ASYNC_SOCKET_MANAGER_THREAD_STACK_SIZE < PTHREAD_STACK_MIN)
+diff --git a/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/RTOS/pal_plat_rtos.c b/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/RTOS/pal_plat_rtos.c
+index 8c94312..2ffc158 100644
+--- a/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/RTOS/pal_plat_rtos.c
++++ b/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/RTOS/pal_plat_rtos.c
+@@ -269,11 +269,13 @@ palStatus_t pal_plat_osThreadCreate(palThreadFuncPtr function, void* funcArgumen
+         goto finish;
+     }
+ 
++#if REAL_TIME_SCHEDULING_ENABLED
+     err = pthread_attr_setschedpolicy(ptrAttr, SCHED_RR);
+     if (0 != err)
+     {
+         goto finish;
+     }
++#endif
+ 
+ #if (PAL_SIMULATOR_TEST_ENABLE == 0) // disable ONLY for Linux PC simulator 
+     err = pthread_attr_setinheritsched(ptrAttr, PTHREAD_EXPLICIT_SCHED);
+@@ -289,12 +291,14 @@ palStatus_t pal_plat_osThreadCreate(palThreadFuncPtr function, void* funcArgumen
+         goto finish;
+     }    
+     
++#if REAL_TIME_SCHEDULING_ENABLED
+     schedParam.sched_priority = PAL_THREAD_PRIORITY_TRANSLATE(priority);
+     err = pthread_attr_setschedparam(ptrAttr, &schedParam);
+     if (0 != err)
+     {
+         goto finish;
+     }
++#endif
+ 
+     threadData = (palThreadData_t*)malloc(sizeof(palThreadData_t));
+     if (NULL == threadData)
+-- 
+2.10.1.windows.1
+

--- a/mbed-fcc/deb/debian/patches/0004-Turn-off-real-time-scheduling.patch
+++ b/mbed-fcc/deb/debian/patches/0004-Turn-off-real-time-scheduling.patch
@@ -1,0 +1,27 @@
+From b1b6c242a33bcb88fba657463a1a6d9d29aa9f8b Mon Sep 17 00:00:00 2001
+From: Michael Ray <michael.ray@arm.com>
+Date: Tue, 23 Mar 2021 16:14:19 -0500
+Subject: [PATCH] Turn off real-time scheduling
+
+Look at this later to see if there is a more elegant solution
+---
+ mbed-client-pal/Configs/pal_config/Linux/Linux_default.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/mbed-client-pal/Configs/pal_config/Linux/Linux_default.h b/mbed-client-pal/Configs/pal_config/Linux/Linux_default.h
+index f3d3505..6f3ca7a 100644
+--- a/mbed-client-pal/Configs/pal_config/Linux/Linux_default.h
++++ b/mbed-client-pal/Configs/pal_config/Linux/Linux_default.h
+@@ -214,6 +214,9 @@
+ #warning "PAL_NOISE_TRNG_THREAD_STACK_SIZE stack size is less than PTHREAD_STACK_MIN"
+ #endif
+ 
++// Turn off real-time scheduling
++#undef REAL_TIME_SCHEDULING_ENABLED
++
+ // Define this to use static memory buffer for mbedtls, instead of standard mbedtls memory system (default is using heap).
+ //#undef PAL_USE_STATIC_MEMBUF_FOR_MBEDTLS
+ 
+-- 
+2.10.1.windows.1
+

--- a/mbed-fcc/deb/debian/patches/series
+++ b/mbed-fcc/deb/debian/patches/series
@@ -1,3 +1,4 @@
 0001-fix-build-getting-cross-compiler-iface-setting-to-et.patch
 0002-Modified-FCCE-to-take-in-CBOR-file-to-generate-the-s.patch
 0003-Add-support-for-OS-s-that-do-not-have-RT-scheduling-.patch
+0004-Turn-off-real-time-scheduling.patch

--- a/mbed-fcc/deb/debian/patches/series
+++ b/mbed-fcc/deb/debian/patches/series
@@ -1,3 +1,3 @@
 0001-fix-build-getting-cross-compiler-iface-setting-to-et.patch
 0002-Modified-FCCE-to-take-in-CBOR-file-to-generate-the-s.patch
-
+0003-Add-support-for-OS-s-that-do-not-have-RT-scheduling-.patch


### PR DESCRIPTION
Added a patch that enables/disables RT scheduling support
Turn it off to remove specific pthread calls

Add the patch to the mbed-fcc series file