### PR TITLE
add pelion helper script

### DIFF
--- a/pe-utils/deb/debian/pelion.sh
+++ b/pe-utils/deb/debian/pelion.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+SERVICES="edge-core edge-proxy kubelet maestro pelion-relay-term devicedb wait-for-pelion-identity"
+
+function installed() {
+	local services=""
+	for s in ${SERVICES}; do
+		if dpkg -l $s &>/dev/null; then
+			services="${services} $s"
+		fi
+	done
+	echo ${services}
+}
+
+ACTION=$1
+case ${ACTION} in
+	installed)
+		i=$(installed)
+		echo "    installed: ${i}"
+		echo "not installed: $(echo ${i} ${SERVICES} | uniq -u)"
+		;;
+
+	status)
+		for s in $(installed); do
+			systemctl status $s --lines 0 --no-pager
+		done
+		;;
+
+	stop|start|restart|disable|enable)
+		for s in $(installed); do
+			systemctl $ACTION $s
+		done
+		;;
+
+	*)
+		echo "${ACTION}: unknown command"
+		exit 1
+		;;
+esac

--- a/pe-utils/deb/debian/rules
+++ b/pe-utils/deb/debian/rules
@@ -11,3 +11,7 @@ override_dh_systemd_enable:
 
 override_dh_systemd_start:
 	dh_systemd_start --name=wait-for-pelion-identity wait-for-pelion-identity.service
+
+override_dh_auto_install:
+	dh_auto_install
+	install -D -m 755 debian/pelion.sh $(CURDIR)/debian/pe-utils/usr/bin/pelion


### PR DESCRIPTION
the script can be used as a convenience to check status of all
installed pelion services like edge-core, edge-proxy, maestro, etc.