### PR TITLE
mbed-edge-core: add platform version file

### DIFF
--- a/mbed-edge-core-devmode/deb/build.sh
+++ b/mbed-edge-core-devmode/deb/build.sh
@@ -18,6 +18,7 @@ function pelion_mbed_edge_core_source_preparation_cb() {
     cp "$PELION_PACKAGE_DIR/../../update_default_resources.c" "./config/update_default_resources.c"
     cp "$PELION_PACKAGE_DIR/debian/files/sotp_fs_linux.h" "./config/sotp_fs_linux.h"
     cp "$PELION_PACKAGE_DIR/debian/files/osreboot.c" "./edge-core/osreboot.c"
+    cp "$PELION_PACKAGE_DIR/debian/files/mbed_cloud_client_user_config.h" "./config/mbed_cloud_client_user_config.h"
 }
 
 pelion_main "$@"

--- a/mbed-edge-core-devmode/deb/debian/files/mbed_cloud_client_user_config.h
+++ b/mbed-edge-core-devmode/deb/debian/files/mbed_cloud_client_user_config.h
@@ -1,0 +1,48 @@
+/*
+ * ----------------------------------------------------------------------------
+ * Copyright 2018 ARM Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+
+/*
+ * Minimal configuration for using mbed-cloud-client
+ */
+
+#ifndef MBED_CLOUD_CLIENT_USER_CONFIG_H
+#define MBED_CLOUD_CLIENT_USER_CONFIG_H
+
+#define MBED_CLOUD_CLIENT_SUPPORT_CLOUD
+#define MBED_CLOUD_CLIENT_ENDPOINT_TYPE          "MBED_GW"
+#define MBED_CLOUD_CLIENT_TRANSPORT_MODE_TCP
+#define MBED_CLOUD_CLIENT_LIFETIME               3600
+
+#define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE       1024
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT       0
+#define SN_COAP_DISABLE_RESENDINGS               1
+
+/* set download buffer size in bytes (min. 1024 bytes) */
+#define MBED_CLOUD_CLIENT_UPDATE_BUFFER          (2 * 1024 * 1024)
+
+/* set the TCP KEEPALIVE values */
+#define MBED_CLIENT_TCP_KEEPALIVE_INTERVAL 60
+#define MBED_CLIENT_TCP_KEEPALIVE_TIME 60
+
+#define PLATFORM_VERSION_HASH_FILE "/etc/pelion/platform_version"
+#define PLATFORM_VERSION_FILE "/etc/pelion/readable_version"
+
+#endif /* MBED_CLIENT_USER_CONFIG_H */
+

--- a/mbed-edge-core-devmode/deb/debian/patches/Read-platform-version-files-into-LWM2M-resources.patch
+++ b/mbed-edge-core-devmode/deb/debian/patches/Read-platform-version-files-into-LWM2M-resources.patch
@@ -1,0 +1,112 @@
+From fe1c7266cf90c6bc0e746da7e6d3702bde2bb1c0 Mon Sep 17 00:00:00 2001
+From: Michael Ray <mjray@umich.edu>
+Date: Wed, 25 Mar 2020 14:20:17 -0500
+Subject: [PATCH 05/15] Read platform version files into LWM2M resources
+
+Platform Version readable: /10252/0/10
+Platform Version MD5 hash: /10252/0/11
+
+Check for files specified in macros:
+* PLATFORM_VERSION_FILE
+* PLATFORM_VERSION_HASH_FILE
+
+If either macro is not found, use:
+* /etc/readable_version
+* /etc/platform_version
+
+If the files do not exist at all, version becomes -1 which was default
+before this change
+
+Note: /10252/0/6 is the package version, which is required to be  set
+to the timestamp in the  manifest during a firmware update.
+
+Originally, we wanted to use this LWM2M resource to store the version,
+but a FOTA would not complete without setting it to the expected time
+(named hash in the resource name)
+---
+ .../source/FirmwareUpdateResource.cpp         | 55 +++++++++++++++++++
+ 1 file changed, 55 insertions(+)
+
+diff --git a/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp b/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
+index 628c0d2..fbe1e5f 100644
+--- a/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
++++ b/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
+@@ -50,6 +50,14 @@
+ #define RESOURCE_VALUE(arg) #arg
+ #endif
+ 
++#ifndef PLATFORM_VERSION_FILE
++#define PLATFORM_VERSION_FILE "/etc/readable_version"
++#endif
++
++#ifndef PLATFORM_VERSION_HASH_FILE
++#define PLATFORM_VERSION_HASH_FILE "/etc/platform_version"
++#endif
++
+ namespace FirmwareUpdateResource {
+ 
+ /* send delayed response */
+@@ -89,6 +97,8 @@ static M2MResource *resourceState = NULL;
+ static M2MResource *resourceResult = NULL;
+ static M2MResource *resourceName = NULL;
+ static M2MResource *resourceVersion = NULL;
++static M2MResource *resourcePlatVersion = NULL;
++static M2MResource *resourcePlatVersionHash = NULL;
+ 
+ /* function pointers to callback functions */
+ static void (*externalPackageCallback)(const uint8_t *buffer, uint16_t length) = NULL;
+@@ -217,6 +227,51 @@ void FirmwareUpdateResource::Initialize(void)
+                     resourceVersion->set_auto_observable(true);
+                 }
+ 
++                char buffer[33];
++                FILE *fp = NULL;
++
++                /* Create Platform Version resource /10252/0/10 */
++                resourcePlatVersion = updateInstance->create_dynamic_resource(
++                                      RESOURCE_VALUE(10), "PlatVersion", M2MResourceInstance::STRING, true);
++                if (resourcePlatVersion) {
++                    fp = fopen(PLATFORM_VERSION_FILE, "r");
++                    if (fp) {
++                        /* Strip out the newline if exists since we don't want it in the LWM2M object */
++                        memset(buffer, 0, sizeof(buffer));
++                        if (fgets(buffer, sizeof(buffer), fp) && buffer[strlen(buffer) - 1] == '\n') {
++                            buffer[strlen(buffer)-1] = 0;
++                        }
++                        resourcePlatVersion->set_value((uint8_t*)buffer, strlen(buffer));
++                        fclose(fp);
++                    } else {
++                        resourcePlatVersion->set_value(defaultVersion, sizeof(defaultVersion) - 1);
++                    }
++                    resourcePlatVersion->set_operation(M2MBase::GET_ALLOWED);
++                    resourcePlatVersion->publish_value_in_registration_msg(true);
++                    resourcePlatVersion->set_auto_observable(true);
++                }
++
++                /* Create Platform Version Hash resource /10252/0/11 */
++                resourcePlatVersionHash = updateInstance->create_dynamic_resource(
++                                          RESOURCE_VALUE(11), "PlatVersionHash", M2MResourceInstance::STRING, true);
++                if (resourcePlatVersionHash) {
++                    fp = fopen(PLATFORM_VERSION_HASH_FILE, "r");
++                    if (fp) {
++                        /* Strip out the newline if exists since we don't want it in the LWM2M object */
++                        memset(buffer, 0, sizeof(buffer));
++                        if (fgets(buffer, sizeof(buffer), fp) && buffer[strlen(buffer) - 1] == '\n') {
++                            buffer[strlen(buffer)-1] = 0;
++                        }
++                        resourcePlatVersionHash->set_value((uint8_t*)buffer, strlen(buffer));
++                        fclose(fp);
++                    } else {
++                        resourcePlatVersionHash->set_value(defaultVersion, sizeof(defaultVersion) - 1);
++                    }
++                    resourcePlatVersionHash->set_operation(M2MBase::GET_ALLOWED);
++                    resourcePlatVersionHash->publish_value_in_registration_msg(true);
++                    resourcePlatVersionHash->set_auto_observable(true);
++                }
++
+ #if !defined(ARM_UC_PROFILE_MBED_CLIENT_LITE) || (ARM_UC_PROFILE_MBED_CLIENT_LITE == 0)
+                 /* Create Update resource /10252/0/9 */
+                 resourceUpdate = updateInstance->create_dynamic_resource(
+-- 
+2.17.1
+

--- a/mbed-edge-core-devmode/deb/debian/patches/series
+++ b/mbed-edge-core-devmode/deb/debian/patches/series
@@ -8,3 +8,4 @@ patch-mbed-edge-with-the-ability-to-override-pelion-.patch
 Remove-Version.patch
 Fix-CPU-Temp-Path.patch
 Add-support-for-network-proxy.patch
+Read-platform-version-files-into-LWM2M-resources.patch

--- a/mbed-edge-core/deb/build.sh
+++ b/mbed-edge-core/deb/build.sh
@@ -15,6 +15,7 @@ function pelion_mbed_edge_core_source_preparation_cb() {
     cd "$PELION_SOURCE_DIR/$PELION_PACKAGE_NAME/mbed-edge"
     git submodule update --init --recursive
     cp "$PELION_PACKAGE_DIR/debian/files/sotp_fs_linux.h" "./config/sotp_fs_linux.h"
+    cp "$PELION_PACKAGE_DIR/debian/files/mbed_cloud_client_user_config.h" "./config/mbed_cloud_client_user_config.h"
 }
 
 pelion_main "$@"

--- a/mbed-edge-core/deb/debian/files/mbed_cloud_client_user_config.h
+++ b/mbed-edge-core/deb/debian/files/mbed_cloud_client_user_config.h
@@ -1,0 +1,48 @@
+/*
+ * ----------------------------------------------------------------------------
+ * Copyright 2018 ARM Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+
+/*
+ * Minimal configuration for using mbed-cloud-client
+ */
+
+#ifndef MBED_CLOUD_CLIENT_USER_CONFIG_H
+#define MBED_CLOUD_CLIENT_USER_CONFIG_H
+
+#define MBED_CLOUD_CLIENT_SUPPORT_CLOUD
+#define MBED_CLOUD_CLIENT_ENDPOINT_TYPE          "MBED_GW"
+#define MBED_CLOUD_CLIENT_TRANSPORT_MODE_TCP
+#define MBED_CLOUD_CLIENT_LIFETIME               3600
+
+#define SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE       1024
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT       0
+#define SN_COAP_DISABLE_RESENDINGS               1
+
+/* set download buffer size in bytes (min. 1024 bytes) */
+#define MBED_CLOUD_CLIENT_UPDATE_BUFFER          (2 * 1024 * 1024)
+
+/* set the TCP KEEPALIVE values */
+#define MBED_CLIENT_TCP_KEEPALIVE_INTERVAL 60
+#define MBED_CLIENT_TCP_KEEPALIVE_TIME 60
+
+#define PLATFORM_VERSION_HASH_FILE "/etc/pelion/platform_version"
+#define PLATFORM_VERSION_FILE "/etc/pelion/readable_version"
+
+#endif /* MBED_CLIENT_USER_CONFIG_H */
+

--- a/mbed-edge-core/deb/debian/patches/Read-platform-version-files-into-LWM2M-resources.patch
+++ b/mbed-edge-core/deb/debian/patches/Read-platform-version-files-into-LWM2M-resources.patch
@@ -1,0 +1,112 @@
+From fe1c7266cf90c6bc0e746da7e6d3702bde2bb1c0 Mon Sep 17 00:00:00 2001
+From: Michael Ray <mjray@umich.edu>
+Date: Wed, 25 Mar 2020 14:20:17 -0500
+Subject: [PATCH 05/15] Read platform version files into LWM2M resources
+
+Platform Version readable: /10252/0/10
+Platform Version MD5 hash: /10252/0/11
+
+Check for files specified in macros:
+* PLATFORM_VERSION_FILE
+* PLATFORM_VERSION_HASH_FILE
+
+If either macro is not found, use:
+* /etc/readable_version
+* /etc/platform_version
+
+If the files do not exist at all, version becomes -1 which was default
+before this change
+
+Note: /10252/0/6 is the package version, which is required to be  set
+to the timestamp in the  manifest during a firmware update.
+
+Originally, we wanted to use this LWM2M resource to store the version,
+but a FOTA would not complete without setting it to the expected time
+(named hash in the resource name)
+---
+ .../source/FirmwareUpdateResource.cpp         | 55 +++++++++++++++++++
+ 1 file changed, 55 insertions(+)
+
+diff --git a/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp b/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
+index 628c0d2..fbe1e5f 100644
+--- a/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
++++ b/lib/mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/source/FirmwareUpdateResource.cpp
+@@ -50,6 +50,14 @@
+ #define RESOURCE_VALUE(arg) #arg
+ #endif
+ 
++#ifndef PLATFORM_VERSION_FILE
++#define PLATFORM_VERSION_FILE "/etc/readable_version"
++#endif
++
++#ifndef PLATFORM_VERSION_HASH_FILE
++#define PLATFORM_VERSION_HASH_FILE "/etc/platform_version"
++#endif
++
+ namespace FirmwareUpdateResource {
+ 
+ /* send delayed response */
+@@ -89,6 +97,8 @@ static M2MResource *resourceState = NULL;
+ static M2MResource *resourceResult = NULL;
+ static M2MResource *resourceName = NULL;
+ static M2MResource *resourceVersion = NULL;
++static M2MResource *resourcePlatVersion = NULL;
++static M2MResource *resourcePlatVersionHash = NULL;
+ 
+ /* function pointers to callback functions */
+ static void (*externalPackageCallback)(const uint8_t *buffer, uint16_t length) = NULL;
+@@ -217,6 +227,51 @@ void FirmwareUpdateResource::Initialize(void)
+                     resourceVersion->set_auto_observable(true);
+                 }
+ 
++                char buffer[33];
++                FILE *fp = NULL;
++
++                /* Create Platform Version resource /10252/0/10 */
++                resourcePlatVersion = updateInstance->create_dynamic_resource(
++                                      RESOURCE_VALUE(10), "PlatVersion", M2MResourceInstance::STRING, true);
++                if (resourcePlatVersion) {
++                    fp = fopen(PLATFORM_VERSION_FILE, "r");
++                    if (fp) {
++                        /* Strip out the newline if exists since we don't want it in the LWM2M object */
++                        memset(buffer, 0, sizeof(buffer));
++                        if (fgets(buffer, sizeof(buffer), fp) && buffer[strlen(buffer) - 1] == '\n') {
++                            buffer[strlen(buffer)-1] = 0;
++                        }
++                        resourcePlatVersion->set_value((uint8_t*)buffer, strlen(buffer));
++                        fclose(fp);
++                    } else {
++                        resourcePlatVersion->set_value(defaultVersion, sizeof(defaultVersion) - 1);
++                    }
++                    resourcePlatVersion->set_operation(M2MBase::GET_ALLOWED);
++                    resourcePlatVersion->publish_value_in_registration_msg(true);
++                    resourcePlatVersion->set_auto_observable(true);
++                }
++
++                /* Create Platform Version Hash resource /10252/0/11 */
++                resourcePlatVersionHash = updateInstance->create_dynamic_resource(
++                                          RESOURCE_VALUE(11), "PlatVersionHash", M2MResourceInstance::STRING, true);
++                if (resourcePlatVersionHash) {
++                    fp = fopen(PLATFORM_VERSION_HASH_FILE, "r");
++                    if (fp) {
++                        /* Strip out the newline if exists since we don't want it in the LWM2M object */
++                        memset(buffer, 0, sizeof(buffer));
++                        if (fgets(buffer, sizeof(buffer), fp) && buffer[strlen(buffer) - 1] == '\n') {
++                            buffer[strlen(buffer)-1] = 0;
++                        }
++                        resourcePlatVersionHash->set_value((uint8_t*)buffer, strlen(buffer));
++                        fclose(fp);
++                    } else {
++                        resourcePlatVersionHash->set_value(defaultVersion, sizeof(defaultVersion) - 1);
++                    }
++                    resourcePlatVersionHash->set_operation(M2MBase::GET_ALLOWED);
++                    resourcePlatVersionHash->publish_value_in_registration_msg(true);
++                    resourcePlatVersionHash->set_auto_observable(true);
++                }
++
+ #if !defined(ARM_UC_PROFILE_MBED_CLIENT_LITE) || (ARM_UC_PROFILE_MBED_CLIENT_LITE == 0)
+                 /* Create Update resource /10252/0/9 */
+                 resourceUpdate = updateInstance->create_dynamic_resource(
+-- 
+2.17.1
+

--- a/mbed-edge-core/deb/debian/patches/series
+++ b/mbed-edge-core/deb/debian/patches/series
@@ -1,1 +1,2 @@
 Add-support-for-network-proxy.patch
+Read-platform-version-files-into-LWM2M-resources.patch


### PR DESCRIPTION
This adds two LwM2M Resources intended for reporting platform versions.
The contents of each resource is read from a corresponding file on disk,
and it's up to the user to decide what values to write to the file.

It is intended for one file to contain a "friendly" or "readable" version
string, perhaps something that follows semantic versioning, and for the
other file to contain a hash over some data, such as the md5 hash of
a list of all installed packages.

Platform Version friendly version:
	file: /var/lib/pelion/readable_version
	lwm2m: /10252/0/10

Platform Version MD5 hash:
	file: /var/lib/pelion/platform_version
	lwm2m: /10252/0/11