### PR TITLE
maestro-shell: remove extra symlink to maestro-shell.sh

### DIFF
--- a/maestro-shell/deb/debian/install
+++ b/maestro-shell/deb/debian/install
@@ -1,2 +1,1 @@
-debian/maestro-shell.sh /usr/bin/
-go-workspace/src/github.com/armPelionEdge/maestro-shell/maestro-shell usr/bin/pelion/
+go-workspace/src/github.com/armPelionEdge/maestro-shell/maestro-shell usr/lib/pelion/bin

--- a/maestro-shell/deb/debian/maestro-shell.links
+++ b/maestro-shell/deb/debian/maestro-shell.links
@@ -1,1 +1,0 @@
-/usr/bin/maestro-shell.sh /usr/bin/maestro-shell

--- a/maestro-shell/deb/debian/maestro-shell.sh
+++ b/maestro-shell/deb/debian/maestro-shell.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-LD_LIBRARY_PATH=/usr/lib/pelion  /usr/bin/pelion/maestro-shell
+LD_LIBRARY_PATH=/usr/lib/pelion  /usr/lib/pelion/bin/maestro-shell

--- a/maestro-shell/deb/debian/rules
+++ b/maestro-shell/deb/debian/rules
@@ -18,5 +18,9 @@ override_dh_makeshlibs:
 override_dh_installinit:
 	dh_installinit --no-scripts
 
+override_dh_auto_install:
+	dh_auto_install
+	install -D -m 755 debian/maestro-shell.sh $(CURDIR)/debian/maestro-shell/usr/bin/maestro-shell
+
 override_dh_shlibdeps:
 #override and skip shared libs

--- a/maestro-shell/rpm/files/maestro-shell
+++ b/maestro-shell/rpm/files/maestro-shell
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-LD_LIBRARY_PATH=/usr/lib/pelion  /usr/bin/pelion/maestro-shell
+LD_LIBRARY_PATH=/usr/lib/pelion  /usr/lib/pelion/bin/maestro-shell

--- a/maestro-shell/rpm/maestro-shell.spec
+++ b/maestro-shell/rpm/maestro-shell.spec
@@ -31,12 +31,14 @@ An interactive shell for controlling maestro locally on deviceOS.
 %gobuild -o %{gobuilddir}/bin/%{name} %{goipath}
 
 %install
-install -vdm 0755                            %{buildroot}/%{_bindir}/pelion/
-install -vpm 0755 %{gobuilddir}/bin/*        %{buildroot}/%{_bindir}/pelion/
+install -vdm 0755                            %{buildroot}/usr/lib/pelion/bin
+install -vpm 0755 %{gobuilddir}/bin/*        %{buildroot}/usr/lib/pelion/bin/
+install -vdm 0755                            %{buildroot}/%{_bindir}
 install -vpm 0755 %{_filesdir}/maestro-shell %{buildroot}/%{_bindir}/
 
 %files
 %{_bindir}/*
+/usr/lib/pelion/bin/*
 
 %changelog
 * Wed May 20 2020 Vasily Smirnov <vasilii.smirnov@globallogic.com> - 0.0.1-1


### PR DESCRIPTION
this is just a cleanup that renames the maestro-shell.sh script to
maestro-shell during installation rather that creating a symlink
with the same name.

this also removes the subfolder /usr/bin/pelion/ which only
contained the maestro-shell binary.