### PR TITLE
Use correct bash interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ centos/8 rhel/8
 
 ## Preparing host to compile packages
 ### System requirements
-The `build-all.sh` Script requires docker, bash 4.2+ and gnu-getopt.
+The  `build-all.sh`  script  requires   docker,  bash  4.2+,  gnu-findutils  and
+gnu-getopt.
 
 To  build arm64  packages  for *Red  Hat*  or *Centos*  `qemu`  is required  and
 qemu-docker  integration  because  *Red  Hat*/*Centos* does  not  support  cross

--- a/build-env/bin/build-all.sh
+++ b/build-env/bin/build-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source ${BASH_SOURCE[0]%/*}/../inc/build-all/runner.sh
 
 opt_usage="${0##*/} - build all packages:

--- a/build-env/bin/docker-run-env.sh
+++ b/build-env/bin/docker-run-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source ${BASH_SOURCE%/*}/../inc/build-all/runner.sh
 


### PR DESCRIPTION
To run new build scripts on MacOS, `build-all.sh` and `docker-run-env.sh`  has to use `/usr/bin/env` to select correct bash interpreter (instead of hardcoded `/bin/bash`). 