### PR TITLE
Warn about iptables bug

### DIFF
--- a/kubelet/deb/debian/launch-kubelet.sh
+++ b/kubelet/deb/debian/launch-kubelet.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 IDENTITY_JSON=${IDENTITY_JSON:-/var/lib/pelion/edge_gw_config/identity.json}
 DEVICE_ID=$(jq -r .deviceID ${IDENTITY_JSON})
@@ -21,6 +21,29 @@ if [ -n $IP_ADDR ]; then
 else
     NODE_IP_OPTION=""
 fi
+
+FIRST_BROKEN_VERSION='iptables v1.8.0'
+FIRST_WORKING_VERSION='iptables v1.8.3'
+IPTVERSION=$(iptables --version)
+
+# check if iptables is between the min and max version if so we have a bugged iptables
+if ! [ "$(echo -e ${FIRST_BROKEN_VERSION}\\n${IPTVERSION} | sort -V | head -1)" != "${FIRST_BROKEN_VERSION}" -o \
+       "$(echo -e ${FIRST_WORKING_VERSION}\\n${IPTVERSION} | sort -V | tail -1)" != "${FIRST_WORKING_VERSION}" ]; then
+    # if the iptables == iptables-legacy versions we are in good shape
+    # we don't work correctly on debian with iptables-nft
+    if [[ "${IPTVERSION}" != "$(iptables-legacy --version)" ]]; then
+        echo 'WARNING starting kublet:'
+        echo 'There is a bug in iptables versions 1.8.0->1.8.2 that causes kubelet to create duplicate firewall rules.'
+        echo
+        echo 'For more information, see the following known issues:'
+        echo '  https://github.com/kubernetes/kubernetes/issues/71305'
+        echo '  https://github.com/kubernetes/kubernetes/issues/76431'
+        echo
+        echo 'Some suggested workarounds include:'
+        echo '  Run the following command on the host: update-alternatives --set iptables /usr/sbin/iptables-legacy'
+        echo '  Upgrade iptables to version 1.8.3+'
+    fi
+fi 
 
 exec /usr/bin/kubelet \
     --root-dir=/var/lib/pelion/kubelet \


### PR DESCRIPTION
The launch kublet script now warns the user about a leaking bug
in iptables that causes the KUBE-FIREWALL table to fill up and
directs them to the bug on github and its potential fixes.