### PR TITLE
Fixing Kubelet build

### DIFF
--- a/build-env/bin/docker-debian-stretch-create.sh
+++ b/build-env/bin/docker-debian-stretch-create.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(cd "`dirname \"$0\"`" && pwd)
 CTX_PATH="$SCRIPT_DIR"/../docker
 DOCKER_FILE_PATH="$CTX_PATH"/docker-debian-9-stretch
 
-docker build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) \
+docker build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg DOCKER_GROUP_ID=$(grep "^docker" /etc/group | cut -d: -f3) \
     -t ${PELION_DOCKER_PREFIX}pelion-stretch-build -f "$DOCKER_FILE_PATH/Dockerfile.build" "$CTX_PATH"
 
 docker build --build-arg PREFIX=$PELION_DOCKER_PREFIX \

--- a/build-env/bin/docker-ubuntu-bionic-create.sh
+++ b/build-env/bin/docker-ubuntu-bionic-create.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(cd "`dirname \"$0\"`" && pwd)
 CTX_PATH="$SCRIPT_DIR"/../docker
 DOCKER_FILE_PATH="$CTX_PATH"/docker-ubuntu-18-bionic
 
-docker build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) \
+docker build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg DOCKER_GROUP_ID=$(grep "^docker" /etc/group | cut -d: -f3) \
     -t ${PELION_DOCKER_PREFIX}pelion-bionic-build -f "$DOCKER_FILE_PATH/Dockerfile.build" "$CTX_PATH"
 
 docker build --build-arg PREFIX=$PELION_DOCKER_PREFIX \

--- a/build-env/bin/docker-ubuntu-focal-create.sh
+++ b/build-env/bin/docker-ubuntu-focal-create.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR=$(cd "`dirname \"$0\"`" && pwd)
 CTX_PATH="$SCRIPT_DIR"/../docker
 DOCKER_FILE_PATH="$CTX_PATH"/docker-ubuntu-20-focal
 
-docker build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) \
+docker build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg DOCKER_GROUP_ID=$(grep "^docker" /etc/group | cut -d: -f3) \
     -t ${PELION_DOCKER_PREFIX}pelion-focal-build -f "$DOCKER_FILE_PATH/Dockerfile.build" "$CTX_PATH"
 
 docker build --build-arg PREFIX=$PELION_DOCKER_PREFIX \

--- a/build-env/bin/docker-ubuntu-xenial-create.sh
+++ b/build-env/bin/docker-ubuntu-xenial-create.sh
@@ -6,5 +6,5 @@ SCRIPT_DIR=$(cd "`dirname \"$0\"`" && pwd)
 CTX_PATH="$SCRIPT_DIR"/../docker
 DOCKER_FILE_PATH="$CTX_PATH"/docker-ubuntu-16-xenial
 
-docker build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) \
-    -t ${PELION_DOCKER_PREFIX}ubuntu1604-clean -f "$DOCKER_FILE_PATH"/Dockerfile "$CTX_PATH"
+docker build --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg DOCKER_GROUP_ID=$(grep "^docker" /etc/group | cut -d: -f3) \
+    -t ${PELION_DOCKER_PREFIX}ubuntu1604-clean -f "$DOCKER_FILE_PATH/Dockerfile" "$CTX_PATH"

--- a/build-env/docker/docker-debian-10-buster/Dockerfile.source
+++ b/build-env/docker/docker-debian-10-buster/Dockerfile.source
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		python \
 		quilt \
 		ssh \
-		vim
+		vim \
+		rsync \
+		docker.io
 
 USER user

--- a/build-env/docker/docker-debian-9-stretch/Dockerfile.build
+++ b/build-env/docker/docker-debian-9-stretch/Dockerfile.build
@@ -2,11 +2,14 @@ FROM debian:9
 
 ARG USER_ID
 ARG GROUP_ID
+ARG DOCKER_GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-debian-9-stretch
 
 RUN groupadd -o --gid $GROUP_ID user
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
+RUN addgroup --gid $DOCKER_GROUP_ID docker
+RUN usermod -aG docker user
 
 COPY $LOCAL_SRC_PATH/sources.list.stretch /etc/apt/sources.list
 COPY $LOCAL_SRC_PATH/preferences /etc/apt/preferences

--- a/build-env/docker/docker-debian-9-stretch/Dockerfile.source
+++ b/build-env/docker/docker-debian-9-stretch/Dockerfile.source
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		python \
 		quilt \
 		ssh \
-		vim
+		vim \
+		rsync \
+		docker.io
 
 USER user

--- a/build-env/docker/docker-ubuntu-16-xenial/Dockerfile
+++ b/build-env/docker/docker-ubuntu-16-xenial/Dockerfile
@@ -2,11 +2,14 @@ FROM ubuntu:16.04
 
 ARG USER_ID
 ARG GROUP_ID
+ARG DOCKER_GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-ubuntu-16-xenial
 
 RUN groupadd -o --gid $GROUP_ID user
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
+RUN addgroup --gid $DOCKER_GROUP_ID docker
+RUN usermod -aG docker user
 
 COPY $LOCAL_SRC_PATH/sources.list.xenial /etc/apt/sources.list
 RUN chmod 644 /etc/apt/sources.list
@@ -25,7 +28,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		ssh \
 		sudo \
 		vim \
-		wget
+		wget \
+		rsync \
+		docker.io
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 

--- a/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
@@ -2,11 +2,14 @@ FROM ubuntu:18.04
 
 ARG USER_ID
 ARG GROUP_ID
+ARG DOCKER_GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-ubuntu-18-bionic
 
 RUN groupadd -o --gid $GROUP_ID user
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
+RUN addgroup --gid $DOCKER_GROUP_ID docker
+RUN usermod -aG docker user
 
 COPY $LOCAL_SRC_PATH/sources.list.bionic /etc/apt/sources.list
 COPY $LOCAL_SRC_PATH/focal.list /etc/apt/sources.list.d
@@ -26,6 +29,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		sudo \
 		wget \
 		git
+
+#install tzdata package
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
+# set your timezone
+RUN ln -fs /usr/share/zoneinfo/America/Chicago /etc/localtime
+RUN dpkg-reconfigure --frontend noninteractive tzdata
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 

--- a/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.source
+++ b/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.source
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		python \
 		quilt \
 		ssh \
-		vim
+		vim \
+		rsync \
+		docker.io
 
 USER user

--- a/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
@@ -2,11 +2,14 @@ FROM ubuntu:20.04
 
 ARG USER_ID
 ARG GROUP_ID
+ARG DOCKER_GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-ubuntu-20-focal
 
 RUN groupadd -o --gid $GROUP_ID user
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
+RUN addgroup --gid $DOCKER_GROUP_ID docker
+RUN usermod -aG docker user
 
 RUN echo "APT::Acquire::Retries \"3\";" > /etc/apt/apt.conf.d/80-retries
 COPY $LOCAL_SRC_PATH/sources.list.focal /etc/apt/sources.list

--- a/build-env/docker/docker-ubuntu-20-focal/Dockerfile.source
+++ b/build-env/docker/docker-ubuntu-20-focal/Dockerfile.source
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		python3 \
 		quilt \
 		ssh \
-		vim
+		vim \
+		rsync \
+		docker.io
 
 USER user

--- a/build-env/target/common/debian_packages.conf.sh
+++ b/build-env/target/common/debian_packages.conf.sh
@@ -52,6 +52,7 @@ function debian_rebuild_packages_gz {
 function env_load_docker {
     REPO_DIR="$ROOT_DIR"/build/repo/$ENV_OS_NAME
     DOCKER_VOLUMES+=( "$REPO_DIR":/opt/apt-repo )
+    DOCKER_VOLUMES+=( /var/run/docker.sock:/var/run/docker.sock )
 
     # prepare repo directory with required files (eg Package.gz or similar)
     if [ ! -d "$REPO_DIR" ]; then

--- a/kubelet/deb/build.sh
+++ b/kubelet/deb/build.sh
@@ -9,4 +9,18 @@ declare -A PELION_PACKAGE_COMPONENTS=(
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 
+string="$@"
+
+if [[ $string == *"--arch=arm64"* ]]; then
+    export OS_CPU="linux/arm64"
+else
+    if [[ $string == *"--arch=armhf"* ]]; then
+        export OS_CPU="linux/arm"
+    else
+        export OS_CPU="linux/amd64"
+    fi
+fi
+
+echo "buildtype=$OS_CPU"
+
 pelion_main "$@"

--- a/kubelet/deb/debian/auto_build
+++ b/kubelet/deb/debian/auto_build
@@ -1,22 +1,37 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-export CC="${DEB_HOST_GNU_TYPE}"-gcc
-export CXX="${DEB_HOST_GNU_TYPE}"-g++
 export PKG_CONFIG="${DEB_HOST_GNU_TYPE}"-pkg-config
 
-export CGO_ENABLED=1
+#export CGO_ENABLED=1
 export GOPATH="$(pwd)/go-workspace"
-
-eval "$(debian/goflags.guess $DEB_HOST_ARCH)"
 
 package=k8s.io/kubernetes
 packagedir=$GOPATH/src/$package
+origpath="$(pwd)"
 
 rm -rf "$GOPATH"
 set -- *
 mkdir -p "$packagedir"
 cp -r "$@" "$packagedir"/
 
-go build -buildmode=pie "$package"/cmd/kubelet
+cd "$packagedir"
+
+echo "building for $OS_CPU"
+build/run.sh make kubelet KUBE_BUILD_PLATFORMS="$OS_CPU"
+
+from_path=""
+
+if [[ $OS_CPU == "linux/arm" ]]; then
+    from_path="$packagedir/_output/dockerized/bin/linux/arm/kubelet"
+else
+    if [[ $OS_CPU == "linux/arm64" ]]; then
+        from_path="$packagedir/_output/dockerized/bin/linux/arm64/kubelet"
+    else
+        from_path="$packagedir/_output/dockerized/bin/linux/amd64/kubelet"
+    fi
+fi
+
+echo "cp $from_path $origpath/"
+cp "$from_path" "$origpath"/


### PR DESCRIPTION
Fixing Kublet so that armhs, arm64, and amd64 now all have version
numbers. This was accomplished by removing our custom build steps
and pivoting to building kubelet using it's own standard build
system.
