### PR TITLE
Fix kubelet build-all fail

### DIFF
--- a/build-env/bin/docker-run.sh
+++ b/build-env/bin/docker-run.sh
@@ -4,7 +4,7 @@ echo "WARNING: this script is deprecated. Use docker-run-env.sh instead"
 ROOT_DIR=$(cd "`dirname \"$0\"`"/../.. && pwd)
 
 DOCKER_DIST=$(echo $1 | cut -d- -f2)
-APT_REPO="$ROOT_DIR"/build/apt/$DOCKER_DIST
+APT_REPO="$ROOT_DIR"/build/repo/$DOCKER_DIST
 echo "Using APT repo dir: " $APT_REPO
 mkdir -p -m 755 $APT_REPO
 

--- a/build-env/bin/pelion-build-all.sh
+++ b/build-env/bin/pelion-build-all.sh
@@ -126,7 +126,7 @@ function pelion_parse_args() {
     fi
 
     # relative path to repo
-    APT_REPO_PATH=build/apt/$DIST_CODENAME
+    APT_REPO_PATH=build/repo/$DIST_CODENAME
 }
 
 # run command in docker

--- a/build-env/docker/docker-debian-10-buster/Dockerfile.build
+++ b/build-env/docker/docker-debian-10-buster/Dockerfile.build
@@ -31,7 +31,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		fakeroot \
 		sudo \
 		wget \
-        git
+        git \
+		rsync \
+		docker.io
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 

--- a/build-env/docker/docker-debian-10-buster/Dockerfile.source
+++ b/build-env/docker/docker-debian-10-buster/Dockerfile.source
@@ -10,8 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		python \
 		quilt \
 		ssh \
-		vim \
-		rsync \
-		docker.io
+		vim
 
 USER user

--- a/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
@@ -28,7 +28,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		fakeroot \
 		sudo \
 		wget \
-		git
+		git \
+		rsync \
+		docker.io
 
 #install tzdata package
 RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata

--- a/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.source
+++ b/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.source
@@ -11,8 +11,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		python \
 		quilt \
 		ssh \
-		vim \
-		rsync \
-		docker.io
+		vim
 
 USER user

--- a/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
@@ -31,7 +31,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		fakeroot \
 		sudo \
 		wget \
-		git
+		git \
+		rsync \
+		docker.io
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 

--- a/build-env/docker/docker-ubuntu-20-focal/Dockerfile.source
+++ b/build-env/docker/docker-ubuntu-20-focal/Dockerfile.source
@@ -10,8 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		python3 \
 		quilt \
 		ssh \
-		vim \
-		rsync \
-		docker.io
+		vim
 
 USER user

--- a/build-env/inc/build-common.sh
+++ b/build-env/inc/build-common.sh
@@ -430,7 +430,7 @@ function pelion_docker_build() {
     SCRIPT_PATH=$(cd "`dirname \"$0\"`" && pwd)
     DOCKER_ROOT_DIR="/pelion-build"
     DOCKER_SCRIPT_PATH=$(echo $SCRIPT_PATH | sed "s:^$ROOT_DIR:$DOCKER_ROOT_DIR:")
-    APT_REPO="$ROOT_DIR"/build/apt/$DOCKER_DIST
+    APT_REPO="$ROOT_DIR"/build/repo/$DOCKER_DIST
     mkdir -p $APT_REPO
 
     # Use separate docker containers for source generation and package build.
@@ -439,6 +439,7 @@ function pelion_docker_build() {
             -v "$HOME/.ssh":/home/user/.ssh \
             -v "$ROOT_DIR":"$DOCKER_ROOT_DIR" \
             -v "$APT_REPO":/opt/apt-repo \
+            -v /var/run/docker.sock:/var/run/docker.sock \
             ${PELION_DOCKER_PREFIX}pelion-$DOCKER_DIST-source \
             "$DOCKER_SCRIPT_PATH/$BASENAME" \
                 --install --arch=$PELION_PACKAGE_TARGET_ARCH --source
@@ -448,6 +449,7 @@ function pelion_docker_build() {
         docker run --rm \
             -v "$ROOT_DIR":"$DOCKER_ROOT_DIR" \
             -v "$APT_REPO":/opt/apt-repo \
+            -v /var/run/docker.sock:/var/run/docker.sock \
             ${PELION_DOCKER_PREFIX}pelion-$DOCKER_DIST-build \
             "$DOCKER_SCRIPT_PATH/$BASENAME" \
                 --install --arch=$PELION_PACKAGE_TARGET_ARCH --build
@@ -457,6 +459,7 @@ function pelion_docker_build() {
         docker run --rm \
             -v "$ROOT_DIR":"$DOCKER_ROOT_DIR" \
             -v "$APT_REPO":/opt/apt-repo \
+            -v /var/run/docker.sock:/var/run/docker.sock \
             ${PELION_DOCKER_PREFIX}pelion-$DOCKER_DIST-build \
             "$DOCKER_SCRIPT_PATH/$BASENAME" \
                 --install --build
@@ -467,6 +470,7 @@ function pelion_docker_build() {
             -v "$HOME/.ssh":/home/user/.ssh \
             -v "$ROOT_DIR":"$DOCKER_ROOT_DIR" \
             -v "$APT_REPO":/opt/apt-repo \
+            -v /var/run/docker.sock:/var/run/docker.sock \
             ${PELION_DOCKER_PREFIX}pelion-$DOCKER_DIST-source \
             "$DOCKER_SCRIPT_PATH/$BASENAME" \
                --arch=$PELION_PACKAGE_TARGET_ARCH --verify

--- a/golang-providers/golang-virtual/deb/build.sh
+++ b/golang-providers/golang-virtual/deb/build.sh
@@ -10,7 +10,7 @@ PELION_PACKAGE_PRE_BUILD_CALLBACK=cache_golang_packages
 
 function cache_golang_packages() {
     echo "Caching golang-14 in local repository"
-    local OUTPUT_DIR="$ROOT_DIR"/build/apt/$DOCKER_DIST/pe-dependencies/
+    local OUTPUT_DIR="$ROOT_DIR"/build/repo/$DOCKER_DIST/pe-dependencies/
 
     mkdir -p $OUTPUT_DIR
     cd $OUTPUT_DIR


### PR DESCRIPTION
Fixed kubelet build failing in build-all.sh script.

- rsync and docker.io packages moved from Dockerfile.source to Dockerfile.build
- APT_REPO_PATH updated to new name
- docker.sock file access passed to container

@kunal11191 @mohitsingalarm This issue was not detected by CI. Can you check if it can be improved?

Testing scenario

- failed:

```
./build-env/bin/build-all.sh --docker=focal -i
```

- passed:

```
./build-env/bin/docker-run-env.sh focal
./kubelet/deb/build.sh --install
```