### PR TITLE
Fix golang version conflict in RPM build.

### DIFF
--- a/devicedb/rpm/devicedb.spec
+++ b/devicedb/rpm/devicedb.spec
@@ -11,7 +11,7 @@ License:        Apache-2.0
 URL:            %{gourl}
 Source0:        %{gosource}
 
-BuildRequires:  golang >= 1.14, golang < 1.15
+BuildRequires:  golang < 1.15
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units

--- a/edge-proxy/rpm/edge-proxy.spec
+++ b/edge-proxy/rpm/edge-proxy.spec
@@ -11,7 +11,7 @@ License:        Apache-2.0
 URL:            %{gourl}
 Source0:        %{gosource}
 
-BuildRequires:  golang >= 1.14, golang < 1.15
+BuildRequires:  golang < 1.15
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units

--- a/kubelet/rpm/kubelet.spec
+++ b/kubelet/rpm/kubelet.spec
@@ -11,7 +11,7 @@ License:        Apache-2.0
 URL:            %{gourl}
 Source0:        %{gosource}
 
-BuildRequires:  golang >= 1.14, golang < 1.15
+BuildRequires:  golang < 1.15
 Requires:		conntrack-tools docker-ce containernetworking-plugins containernetworking-plugin-c2d ebtables ethtool iproute iptables util-linux socat
 Requires:       edge-proxy pe-utils
 Requires(post): systemd-units

--- a/maestro-shell/rpm/maestro-shell.spec
+++ b/maestro-shell/rpm/maestro-shell.spec
@@ -14,7 +14,7 @@ Patch0:         greaselib-autoreconf.patch
 Patch1:         gperftools-enable-unwind.patch
 
 Requires:       maestro
-BuildRequires:  m4 python27 gcc-c++ golang < 1.15 golang >= 1.14 libunwind-devel
+BuildRequires:  m4 python27 gcc-c++ golang < 1.15 libunwind-devel
 
 %global __requires_exclude (libgrease\\.so\\.1|libtcmalloc_minimal\\.so\\.4)
 

--- a/maestro/rpm/maestro.spec
+++ b/maestro/rpm/maestro.spec
@@ -16,7 +16,7 @@ Patch1:        greaselib-autoreconf.patch
 Patch2:        gperftools-enable-unwind.patch
 Patch3:        eventfd.patch
 
-BuildRequires: m4 python27 gcc-c++ golang < 1.15 golang >= 1.14 libunwind-devel
+BuildRequires: m4 python27 gcc-c++ golang < 1.15 libunwind-devel
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units


### PR DESCRIPTION
Fix for build issue caused by RPM spec file dependency installation algorithm. If package is specified twice yum scripts tries to install both versions and fails.