### PR TITLE
Fix deb and rpm build issues

### DIFF
--- a/build-env/bin/build-all.sh
+++ b/build-env/bin/build-all.sh
@@ -138,6 +138,13 @@ if [ -v arg_print_env ]; then
     exit 0
 fi
 
+# set --install if --docker is in use (and container is not reused)
+if $arg_install || [[ -v arg_docker  &&  ! -v arg_container ]]; then
+    opt_install=true
+else
+    opt_install=false
+fi
+
 # go to root: same for docker and native build
 cd $ROOT_DIR
 

--- a/build-env/inc/build-common.sh
+++ b/build-env/inc/build-common.sh
@@ -308,6 +308,10 @@ function pelion_generation_deb_metapackage() {
         sudo apt-get install -y debhelper
     fi
 
+    if [ -v PELION_PACKAGE_PRE_BUILD_DEP_CALLBACK ]; then
+        $PELION_PACKAGE_PRE_BUILD_DEP_CALLBACK
+    fi
+
     if [ -v PELION_PACKAGE_PRE_BUILD_CALLBACK ]; then
         $PELION_PACKAGE_PRE_BUILD_CALLBACK
     fi
@@ -374,13 +378,17 @@ function pelion_building_deb_package() {
     rm -rf "$PELION_TMP_BUILD_DIR"
     mkdir -p "$PELION_TMP_BUILD_DIR/$PELION_PACKAGE_FOLDER_NAME"
 
-    if [ -v PELION_PACKAGE_PRE_BUILD_CALLBACK ]; then
-        $PELION_PACKAGE_PRE_BUILD_CALLBACK
+    if [ -v PELION_PACKAGE_PRE_BUILD_DEP_CALLBACK ]; then
+        $PELION_PACKAGE_PRE_BUILD_DEP_CALLBACK
     fi
 
     if $PELION_PACKAGE_INSTALL_DEPS; then
         sudo apt-get update && \
         sudo apt-get build-dep -y -a "$PELION_PACKAGE_TARGET_ARCH" "$PELION_DEB_DEPLOY_DIR/source/$PELION_PACKAGE_DEB_ARCHIVE_NAME.dsc" -o APT::Immediate-Configure=0
+    fi
+
+    if [ -v PELION_PACKAGE_PRE_BUILD_CALLBACK ]; then
+        $PELION_PACKAGE_PRE_BUILD_CALLBACK
     fi
 
     tar xf "$PELION_DEB_DEPLOY_DIR/source/$PELION_PACKAGE_ORIG_ARCHIVE_NAME.orig.tar.gz" -C "$PELION_TMP_BUILD_DIR/"

--- a/build-env/inc/env-common.sh
+++ b/build-env/inc/env-common.sh
@@ -1,24 +1,24 @@
-OVERRIDE_BIN_PATH=/opt/bin
+OVERRIDE_PYTHON_BIN_PATH=/opt/bin
 
-export PATH=${OVERRIDE_BIN_PATH}:${PATH}:/usr/lib/pe-golang/bin:/usr/lib/pelion/bin
+export PATH=${OVERRIDE_PYTHON_BIN_PATH}:${PATH}:/usr/lib/pe-golang/bin:/usr/lib/pelion/bin
 
-# link python to python2 or python3 in $OVERRIDE_BIN_PATH dir
+# link python to python2 or python3 in $OVERRIDE_PYTHON_BIN_PATH dir
 # arg: 2 or 3
 function select_python()
 {
     local PY=$(which python"$1")
 
-    if [ $? -ne 0 ];then
+    if [ ! -n "$PY" ];then
         echo "ERROR: cannot find python"$1" in PATH"
         return 1
     fi
 
-    if ! stat $OVERRIDE_BIN_PATH >/dev/null 2>&1; then
-        sudo mkdir -p $OVERRIDE_BIN_PATH
+    if ! stat $OVERRIDE_PYTHON_BIN_PATH >/dev/null 2>&1; then
+        sudo mkdir -p $OVERRIDE_PYTHON_BIN_PATH
     fi
 
     echo "Selecting python"$1" as default python interpreter"
-    sudo ln -fs $PY $OVERRIDE_BIN_PATH/python
+    sudo ln -fs $PY $OVERRIDE_PYTHON_BIN_PATH/python
 }
 
 # depending on arg check if python2, python3 or python is in PATH

--- a/build-env/inc/rpm-common.sh
+++ b/build-env/inc/rpm-common.sh
@@ -176,7 +176,7 @@ deploy() {
 # Overridable.
 all() {
     dispatch download
-    $arg_install && dispatch install_deps
+    $opt_install && dispatch install_deps
     dispatch conjure_sources
     dispatch conjure_spec_files
     dispatch conjure_files
@@ -250,6 +250,13 @@ if [ -v arg_arch ] && [ ! -v arg_docker ]; then
     exit 1
 fi
 
+# set --install if --docker is in use (and container is not reused)
+if $arg_install || [[ -v arg_docker  &&  ! -v arg_container ]]; then
+    opt_install=true
+else
+    opt_install=false
+fi
+
 }
 
 opt_dispatch=parse_args
@@ -292,7 +299,7 @@ if [ -v arg_docker ];then
             args+=( --source )
         fi
 
-        if $arg_install; then
+        if $opt_install; then
             args+=( --install )
         fi
 

--- a/build-env/target/common/debian_packages.conf.sh
+++ b/build-env/target/common/debian_packages.conf.sh
@@ -76,7 +76,7 @@ function run_source {
     shift
     local -a args=('--source')
 
-    if $arg_install; then
+    if $opt_install; then
         args+=('--install')
     fi
 
@@ -96,7 +96,7 @@ function run_build {
     shift
     local -a args=('--build')
 
-    if $arg_install; then
+    if $opt_install; then
         args+=('--install')
     fi
 

--- a/build-env/target/rhel/8/packages.conf.sh
+++ b/build-env/target/rhel/8/packages.conf.sh
@@ -107,7 +107,7 @@ function run_source {
     shift
     local -a args=('--source')
 
-    if $arg_install; then
+    if $opt_install; then
         args+=('--install')
     fi
 
@@ -128,7 +128,7 @@ function run_build {
     shift
     local -a args=('--build')
 
-    if $arg_install; then
+    if $opt_install; then
         args+=('--install')
     fi
 

--- a/golang-providers/golang-virtual/deb/build.sh
+++ b/golang-providers/golang-virtual/deb/build.sh
@@ -6,7 +6,7 @@ PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
 source "$PELION_PACKAGE_DIR"/../../../build-env/inc/build-common.sh
 
-PELION_PACKAGE_PRE_BUILD_CALLBACK=cache_golang_packages
+PELION_PACKAGE_PRE_BUILD_DEP_CALLBACK=cache_golang_packages
 
 function cache_golang_packages() {
     echo "Caching golang-14 in local repository"

--- a/maestro/deb/build.sh
+++ b/maestro/deb/build.sh
@@ -4,6 +4,8 @@
 PELION_PACKAGE_NAME="maestro"
 PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
+PELION_PACKAGE_PRE_BUILD_CALLBACK='select_python 2'
+
 declare -A PELION_PACKAGE_COMPONENTS=(
     ["https://github.com/armPelionEdge/maestro.git"]="20caa5d032424a11146b7923eaaed74e80de96da")
 

--- a/maestro/deb/debian/control
+++ b/maestro/deb/debian/control
@@ -2,7 +2,7 @@ Source: maestro
 Section: utils
 Priority: optional
 Maintainer: Vasily Smirnov <vasilii.smirnov@globallogic.com>
-Build-Depends: debhelper (>=9), pe-golang:native, python:native (>=2.7) | python3:native,
+Build-Depends: debhelper (>=9), pe-golang:native, python:native (>=2.7),
  autoconf (>=2.69), automake (>=1:1.15), libtool (>=2.4.6),
  libc6, libstdc++6, libunwind-dev
 Standards-Version: 3.9.6


### PR DESCRIPTION
This PR solves #145 and #148.

#145 was caused by changes in python package for focal. Maestro assumes `python2` to be available by calling `python`, and `python` command is not provided by default on focal anymore. Change creates `python` symlink to installed `python2` executable so maestro internal dependencies can be build correctly.

#148 was caused by missing `pelion-build-all.sh` feature in `build-all.sh`. Moreover, running build using --docker (and without --container) without `--install` does not makes much sense as it will always fail because of missing build dependencies. 