### PR TITLE
Allow edge-proxy to forward container domain traffic

### DIFF
--- a/edge-proxy/deb/debian/launch-edge-proxy.sh
+++ b/edge-proxy/deb/debian/launch-edge-proxy.sh
@@ -32,13 +32,18 @@ else
     ARGS="${ARGS} -proxy-uri=${EDGE_K8S_ADDRESS}"
 
     GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${IDENTITY_JSON})
-    ARGS="${ARGS} -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"}"
+    CONTAINERS_ADDRESS=$(jq -r .containerServicesAddress ${IDENTITY_JSON})
+    ARGS="${ARGS} -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"\,\"containers.local\":\"${CONTAINERS_ADDRESS#"https://"}\"}"
 fi
 
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path /etc/pelion/edge-proxy.conf.json)
 
 if ! grep -q "gateways.local" /etc/hosts; then
     echo "127.0.0.1 gateways.local" >> /etc/hosts
+fi
+
+if ! grep -q "containers.local" /etc/hosts; then
+    echo "127.0.0.1 containers.local" >> /etc/hosts
 fi
 
 if [[ -n "$HTTP_PROXY" ]]; then

--- a/edge-proxy/deb/debian/launch-edge-proxy.sh
+++ b/edge-proxy/deb/debian/launch-edge-proxy.sh
@@ -33,7 +33,7 @@ else
 
     GATEWAYS_ADDRESS=$(jq -r .gatewayServicesAddress ${IDENTITY_JSON})
     CONTAINERS_ADDRESS=$(jq -r .containerServicesAddress ${IDENTITY_JSON})
-    ARGS="${ARGS} -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}\"\,\"containers.local\":\"${CONTAINERS_ADDRESS#"https://"}\"}"
+    ARGS="${ARGS} -forwarding-addresses={\"gateways.local\":\"${GATEWAYS_ADDRESS#"https://"}"\"\,\"containers.local\":\"${CONTAINERS_ADDRESS#"https://"}"\"}"
 fi
 
 EDGE_PROXY_URI_RELATIVE_PATH=$(jq -r .edge_proxy_uri_relative_path /etc/pelion/edge-proxy.conf.json)


### PR DESCRIPTION

    
1. Modify edge-proxy launch script to add new forwarding address for containers domain
2. Add `containers.local` to the list of known hosts
3. Update pe-utils