### PR TITLE
Upgraded pe-utils to 2.0.7

### DIFF
--- a/pe-utils/deb/build.sh
+++ b/pe-utils/deb/build.sh
@@ -5,7 +5,7 @@ PELION_PACKAGE_NAME="pe-utils"
 PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["https://github.com/armPelionEdge/pe-utils.git"]="cccc67643c2cf0846731573ca0c69faf68a5eb6d")
+    ["https://github.com/armPelionEdge/pe-utils.git"]="f7d3e32373eb5ed8536f70110406ad35c2e5e0cb")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 

--- a/pe-utils/deb/build.sh
+++ b/pe-utils/deb/build.sh
@@ -5,7 +5,7 @@ PELION_PACKAGE_NAME="pe-utils"
 PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["https://github.com/armPelionEdge/pe-utils.git"]="6a436d6986c67f36936a40d31f43462c97b6f615")
+    ["https://github.com/armPelionEdge/pe-utils.git"]="cccc67643c2cf0846731573ca0c69faf68a5eb6d")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 


### PR DESCRIPTION
This version of pe-utils mainly add a generic derivation in identity-tool to generate edge gw urls from all possible values of LwM2M service address. This should allow snap-pelion-edge gateways to connect with any Pelion cloud and on-prem instance.