### PR TITLE
Update debian package versions

### DIFF
--- a/build-env/inc/build-common.sh
+++ b/build-env/inc/build-common.sh
@@ -40,7 +40,7 @@ PELION_TMP_BUILD_DIR=$ROOT_DIR/build/tmp-build/$PELION_PACKAGE_NAME
 
 PELION_PACKAGE_FULL_VERSION=$(cd "$PELION_PACKAGE_DIR"; dpkg-parsechangelog --show-field Version)
 PELION_PACKAGE_VERSION=$(echo $PELION_PACKAGE_FULL_VERSION \
-    | sed -r 's/([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/') # Version without Revision
+    | sed 's/\-[^\-]*$//') # Version without Revision
 
 PELION_PACKAGE_FOLDER_NAME="$PELION_PACKAGE_NAME"-"$PELION_PACKAGE_VERSION"
 PELION_PACKAGE_ORIG_ARCHIVE_NAME="$PELION_PACKAGE_NAME"_"$PELION_PACKAGE_VERSION"

--- a/devicedb/deb/debian/changelog
+++ b/devicedb/deb/debian/changelog
@@ -1,3 +1,9 @@
+devicedb (1.9.4-22-gd24df28-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 10:49:43 -0500
+
 devicedb (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/edge-proxy/deb/debian/changelog
+++ b/edge-proxy/deb/debian/changelog
@@ -1,3 +1,9 @@
+edge-proxy (1.0.0-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 14:38:08 -0500
+
 edge-proxy (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/global-node-modules/deb/build.sh
+++ b/global-node-modules/deb/build.sh
@@ -10,7 +10,7 @@ PELION_PACKAGE_ORIGIN_SOURCE_UPDATE_CALLBACK=pelion_global_node_modules_source_u
 
 declare -A PELION_PACKAGE_COMPONENTS=(
     ["https://github.com/armPelionEdge/edge-node-modules.git"]="1ea6080fcc17e588c4f53c86a6c2b2bd7df3f05c"
-    ["https://github.com/armPelionEdge/devjs-production-tools.git"]="master")
+    ["https://github.com/armPelionEdge/devjs-production-tools.git"]="62b8cdd4b98d3ef843aaf34daf5c4a81234e6788")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 

--- a/global-node-modules/deb/debian/changelog
+++ b/global-node-modules/deb/debian/changelog
@@ -1,3 +1,9 @@
+global-node-modules (0.9.0-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 13:25:05 -0500
+
 global-node-modules (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/kubelet/deb/debian/changelog
+++ b/kubelet/deb/debian/changelog
@@ -1,3 +1,9 @@
+kubelet (0.9.0-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 14:44:05 -0500
+
 kubelet (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/maestro-shell/deb/debian/changelog
+++ b/maestro-shell/deb/debian/changelog
@@ -1,3 +1,9 @@
+maestro-shell (2.6.0-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 14:46:33 -0500
+
 maestro-shell (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/maestro/deb/debian/changelog
+++ b/maestro/deb/debian/changelog
@@ -1,3 +1,9 @@
+maestro (2.10.0-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 14:45:08 -0500
+
 maestro (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/mbed-edge-core-devmode/deb/debian/changelog
+++ b/mbed-edge-core-devmode/deb/debian/changelog
@@ -1,3 +1,9 @@
+mbed-edge-core-devmode (0.13.0-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 14:47:51 -0500
+
 mbed-edge-core-devmode (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/mbed-edge-examples/deb/debian/changelog
+++ b/mbed-edge-examples/deb/debian/changelog
@@ -1,3 +1,9 @@
+mbed-edge-examples (0.10.0-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 14:48:59 -0500
+
 mbed-edge-examples (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/mbed-fcc/deb/debian/changelog
+++ b/mbed-fcc/deb/debian/changelog
@@ -1,3 +1,9 @@
+mbed-fcc (4.6.0-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 14:49:39 -0500
+
 mbed-fcc (0.0.1-1) unstable; urgency=medium
 
   * Initial release

--- a/pe-utils/deb/debian/changelog
+++ b/pe-utils/deb/debian/changelog
@@ -1,3 +1,9 @@
+pe-utils (2.0.7-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Thu, 10 Jun 2021 14:52:15 -0500
+
 pe-utils (0.0.1-1) unstable; urgency=medium
 
   * Initial release


### PR DESCRIPTION
Update versions of debian packages according to our package version
convention.  For global-node-modules, update to the latest since it's
the first tagged version, and correct one place where a version was
floating.