### PR TITLE
Updated the pe-utils 2.0.7 SHA

### DIFF
--- a/pe-utils/deb/build.sh
+++ b/pe-utils/deb/build.sh
@@ -5,7 +5,7 @@ PELION_PACKAGE_NAME="pe-utils"
 PELION_PACKAGE_DIR=$(cd "`dirname \"$0\"`" && pwd)
 
 declare -A PELION_PACKAGE_COMPONENTS=(
-    ["https://github.com/armPelionEdge/pe-utils.git"]="f7d3e32373eb5ed8536f70110406ad35c2e5e0cb")
+    ["https://github.com/armPelionEdge/pe-utils.git"]="f90c6a01714db17b1c97a4912db044c6878a4b59")
 
 source "$PELION_PACKAGE_DIR"/../../build-env/inc/build-common.sh
 


### PR DESCRIPTION
Hey folks, found another bug in the last update so pushed new changes. I recreated 2.0.7 tag so won't have to update the other PRs, just this one as its based on SHA. 