### PR TITLE
Debian: retro update SHA-based package versions

### DIFF
--- a/devicedb/deb/debian/changelog
+++ b/devicedb/deb/debian/changelog
@@ -1,4 +1,4 @@
-devicedb (1.9.4-22-gd24df28-1) unstable; urgency=medium
+devicedb (1.9.4+1589538233+d24df28-1) unstable; urgency=medium
 
   * Update package version
 

--- a/edge-proxy/deb/debian/changelog
+++ b/edge-proxy/deb/debian/changelog
@@ -1,4 +1,4 @@
-edge-proxy (1.0.0-1) unstable; urgency=medium
+edge-proxy (1.0.0+1620153140+8f0f107-1) unstable; urgency=medium
 
   * Update package version
 

--- a/global-node-modules/deb/debian/changelog
+++ b/global-node-modules/deb/debian/changelog
@@ -1,4 +1,4 @@
-global-node-modules (0.9.0-1) unstable; urgency=medium
+global-node-modules (0.9.0+1613075326+1ea6080-1) unstable; urgency=medium
 
   * Update package version
 

--- a/kubelet/deb/debian/changelog
+++ b/kubelet/deb/debian/changelog
@@ -1,4 +1,4 @@
-kubelet (0.9.0-1) unstable; urgency=medium
+kubelet (0.9.0+1592942145+83b266ae-1) unstable; urgency=medium
 
   * Update package version
 

--- a/maestro-shell/deb/debian/changelog
+++ b/maestro-shell/deb/debian/changelog
@@ -1,4 +1,4 @@
-maestro-shell (2.6.0-1) unstable; urgency=medium
+maestro-shell (2.6.0+1597076849+2c90fbe-1) unstable; urgency=medium
 
   * Update package version
 

--- a/maestro/deb/debian/changelog
+++ b/maestro/deb/debian/changelog
@@ -1,4 +1,4 @@
-maestro (2.10.0-1) unstable; urgency=medium
+maestro (2.10.0+1607688609+20caa5d-1) unstable; urgency=medium
 
   * Update package version
 

--- a/pe-utils/deb/debian/changelog
+++ b/pe-utils/deb/debian/changelog
@@ -1,4 +1,4 @@
-pe-utils (2.0.7-1) unstable; urgency=medium
+pe-utils (2.0.7+1623343989+f7d3e32-1) unstable; urgency=medium
 
   * Update package version
 

--- a/rallypointwatchdogs/deb/debian/changelog
+++ b/rallypointwatchdogs/deb/debian/changelog
@@ -1,3 +1,9 @@
+rallypointwatchdogs (1.0.0+1554845858+54ee3bd-1) unstable; urgency=medium
+
+  * Update package version
+
+ -- Mo Chen <mo.chen@pelion.com>  Wed, 16 Jun 2021 10:27:40 -0500
+
 rallypointwatchdogs (0.0.1-1) unstable; urgency=medium
 
   * Initial release


### PR DESCRIPTION
We changed our mind on the package version format for SHA-based
packages.  The new format is sortable and is more robust to different
branching strategies.