### PR TITLE
fix install of mbed-edge-core-devmode with pelion-base

### DIFF
--- a/metapackages/pelion-edge-base/deb/debian/control
+++ b/metapackages/pelion-edge-base/deb/debian/control
@@ -8,6 +8,6 @@ Homepage: https://www.pelion.com
 
 Package: pelion-edge-base
 Architecture: all
-Depends: mbed-edge-core-devmode | mbed-edge-core, maestro, maestro-shell, edge-proxy, devicedb, global-node-modules
+Depends: mbed-edge-core | mbed-edge-core-devmode, maestro, maestro-shell, edge-proxy, devicedb, global-node-modules
 Description: base package group
  Combine mbed-edge-core, maestro, maestro-shell, edge-proxy, devicedb, global-node-modules

--- a/metapackages/pelion-edge/deb/debian/control
+++ b/metapackages/pelion-edge/deb/debian/control
@@ -8,6 +8,6 @@ Homepage: https://www.pelion.com
 
 Package: pelion-edge
 Architecture: all
-Depends: pelion-edge-base, mbed-edge-core, pelion-edge-container-orchestration, mbed-fcc
+Depends: pelion-edge-base, pelion-edge-container-orchestration, mbed-fcc
 Description: Pelion Edge full package set
  Combine pelion base packages and pelion container orchestration packages.


### PR DESCRIPTION
When installing `pelion-edge mbed-edge-core-devmode` together, an
error is returned complaining that pelion-base has an unmet
dependency on mbed-edge-core.