### PR TITLE
Add a github action to build every deb-based distro/arch combination

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distro: [buster, bionic, focal]
+        arch: [amd64, arm64, armhf]
+      fail-fast: false
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Copy mbed_cloud_dev_credentials.c
+        env:
+          MBED_CLOUD_DEV_CREDENTIALS: ${{ secrets.MBED_CLOUD_DEV_CREDENTIALS_C_RYAN }}
+        run: |
+          echo "$MBED_CLOUD_DEV_CREDENTIALS" > mbed_cloud_dev_credentials.c
+      - name: Copy update_default_resources.c
+        env:
+          UPDATE_DEFAULT_RESOURCES: ${{ secrets.UPDATE_DEFAULT_RESOURCES_C_RYAN }}
+        run: |
+          echo "$UPDATE_DEFAULT_RESOURCES" > update_default_resources.c
+      - name: Build
+        run: |
+          export DOCKER_OPTS='-i'; ./build-env/bin/docker-run-env.sh ${{ matrix.distro }} ./build-env/bin/build-all.sh --deps --install --build --source --arch=${{ matrix.arch }}

--- a/build-env/docker/docker-debian-10-buster/Dockerfile.build
+++ b/build-env/docker/docker-debian-10-buster/Dockerfile.build
@@ -5,11 +5,11 @@ ARG GROUP_ID
 ARG DOCKER_GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-debian-10-buster
 
-RUN groupadd -o --gid $GROUP_ID user
+RUN if [ $GROUP_ID != $DOCKER_GROUP_ID ]; then groupadd -o --gid $GROUP_ID user; fi
+RUN addgroup --gid $DOCKER_GROUP_ID docker
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
-RUN addgroup --gid $DOCKER_GROUP_ID docker
-RUN usermod -aG docker user
+RUN if [ $GROUP_ID != $DOCKER_GROUP_ID ]; then usermod -aG docker user; fi
 
 RUN echo "APT::Acquire::Retries \"3\";" > /etc/apt/apt.conf.d/80-retries
 COPY $LOCAL_SRC_PATH/sources.list.buster /etc/apt/sources.list
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
-COPY --chown=user ./common/.bash_aliases /home/user/
+COPY --chown=$USER_ID:$GROUP_ID ./common/.bash_aliases /home/user/
 
 # github.com ssh host key
 COPY ./common/ssh_known_hosts /etc/ssh/ssh_known_hosts

--- a/build-env/docker/docker-debian-9-stretch/Dockerfile.build
+++ b/build-env/docker/docker-debian-9-stretch/Dockerfile.build
@@ -5,11 +5,11 @@ ARG GROUP_ID
 ARG DOCKER_GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-debian-9-stretch
 
-RUN groupadd -o --gid $GROUP_ID user
+RUN if [ $GROUP_ID != $DOCKER_GROUP_ID ]; then groupadd -o --gid $GROUP_ID user; fi
+RUN addgroup --gid $DOCKER_GROUP_ID docker
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
-RUN addgroup --gid $DOCKER_GROUP_ID docker
-RUN usermod -aG docker user
+RUN if [ $GROUP_ID != $DOCKER_GROUP_ID ]; then usermod -aG docker user; fi
 
 COPY $LOCAL_SRC_PATH/sources.list.stretch /etc/apt/sources.list
 COPY $LOCAL_SRC_PATH/preferences /etc/apt/preferences
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
-COPY --chown=user ./common/.bash_aliases /home/user/
+COPY --chown=$USER_ID:$GROUP_ID ./common/.bash_aliases /home/user/
 
 COPY ./common/nodejs-apt-repo.sh /root/
 RUN /root/nodejs-apt-repo.sh && apt-get update

--- a/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
@@ -5,11 +5,11 @@ ARG GROUP_ID
 ARG DOCKER_GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-ubuntu-18-bionic
 
-RUN groupadd -o --gid $GROUP_ID user
+RUN if [ $GROUP_ID != $DOCKER_GROUP_ID ]; then groupadd -o --gid $GROUP_ID user; fi
+RUN addgroup --gid $DOCKER_GROUP_ID docker
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
-RUN addgroup --gid $DOCKER_GROUP_ID docker
-RUN usermod -aG docker user
+RUN if [ $GROUP_ID != $DOCKER_GROUP_ID ]; then usermod -aG docker user; fi
 
 COPY $LOCAL_SRC_PATH/sources.list.bionic /etc/apt/sources.list
 COPY $LOCAL_SRC_PATH/focal.list /etc/apt/sources.list.d
@@ -40,7 +40,7 @@ RUN dpkg-reconfigure --frontend noninteractive tzdata
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
-COPY --chown=user ./common/.bash_aliases /home/user/
+COPY --chown=$USER_ID:$GROUP_ID ./common/.bash_aliases /home/user/
 
 # github.com ssh host key
 COPY ./common/ssh_known_hosts /etc/ssh/ssh_known_hosts

--- a/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
@@ -5,11 +5,11 @@ ARG GROUP_ID
 ARG DOCKER_GROUP_ID
 ARG LOCAL_SRC_PATH=./docker-ubuntu-20-focal
 
-RUN groupadd -o --gid $GROUP_ID user
+RUN if [ $GROUP_ID != $DOCKER_GROUP_ID ]; then groupadd -o --gid $GROUP_ID user; fi
+RUN addgroup --gid $DOCKER_GROUP_ID docker
 RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID user
 RUN usermod -aG sudo user
-RUN addgroup --gid $DOCKER_GROUP_ID docker
-RUN usermod -aG docker user
+RUN if [ $GROUP_ID != $DOCKER_GROUP_ID ]; then usermod -aG docker user; fi
 
 RUN echo "APT::Acquire::Retries \"3\";" > /etc/apt/apt.conf.d/80-retries
 COPY $LOCAL_SRC_PATH/sources.list.focal /etc/apt/sources.list
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
-COPY --chown=user ./common/.bash_aliases /home/user/
+COPY --chown=$USER_ID:$GROUP_ID ./common/.bash_aliases /home/user/
 
 # github.com ssh host key
 COPY ./common/ssh_known_hosts /etc/ssh/ssh_known_hosts


### PR DESCRIPTION
This is some parallel build automation along with Jenkins.  It's an easy way to double check any possible infrastructure issues with the jenkins builds.

Note: that CI is failing here because of the bionic arm64 fluentbit build bug.  [Here's a branch of this with Nic's fix](https://github.com/PelionIoT/distro-pelion-edge/pull/188) showing that CI passes with his fix.  Perhaps we should just wait until that's merged before merging this?