### PR TITLE
Make Dockerfile backwards compatible with docker 18.XX

### DIFF
--- a/build-env/docker/docker-debian-10-buster/Dockerfile.build
+++ b/build-env/docker/docker-debian-10-buster/Dockerfile.build
@@ -37,7 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
-COPY --chown=$USER_ID:$GROUP_ID ./common/.bash_aliases /home/user/
+COPY ./common/.bash_aliases /home/user/
+RUN chown $USER_ID:$GROUP_ID /home/user/.bashrc
 
 # github.com ssh host key
 COPY ./common/ssh_known_hosts /etc/ssh/ssh_known_hosts

--- a/build-env/docker/docker-debian-9-stretch/Dockerfile.build
+++ b/build-env/docker/docker-debian-9-stretch/Dockerfile.build
@@ -32,7 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
-COPY --chown=$USER_ID:$GROUP_ID ./common/.bash_aliases /home/user/
+COPY ./common/.bash_aliases /home/user/
+RUN chown $USER_ID:$GROUP_ID /home/user/.bashrc
 
 COPY ./common/nodejs-apt-repo.sh /root/
 RUN /root/nodejs-apt-repo.sh && apt-get update

--- a/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
@@ -40,7 +40,8 @@ RUN dpkg-reconfigure --frontend noninteractive tzdata
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
-COPY --chown=$USER_ID:$GROUP_ID ./common/.bash_aliases /home/user/
+COPY ./common/.bash_aliases /home/user/
+RUN chown $USER_ID:$GROUP_ID /home/user/.bash_aliases
 
 # github.com ssh host key
 COPY ./common/ssh_known_hosts /etc/ssh/ssh_known_hosts

--- a/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
@@ -37,7 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
-COPY --chown=$USER_ID:$GROUP_ID ./common/.bash_aliases /home/user/
+COPY ./common/.bash_aliases /home/user/
+RUN chown $USER_ID:$GROUP_ID /home/user/.bashrc
 
 # github.com ssh host key
 COPY ./common/ssh_known_hosts /etc/ssh/ssh_known_hosts


### PR DESCRIPTION
ARG expansion in the Dockerfile COPY command is available starting with
docker version 19.XX.  Before that(ex: 18.XX), ARG doesn't get expanded
in the COPY command so you'll get an error like:

    unable to convert uid/gid chown string to host mapping: can't find
    uid for user $USER_ID: no such user: $USER_ID

So, use a separate RUN command to chown instead of trying to do it in
the COPY command.