### PR TITLE
Build the tarballs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           echo "$UPDATE_DEFAULT_RESOURCES" > update_default_resources.c
       - name: Build
         run: |
-          export DOCKER_OPTS='-i'; ./build-env/bin/docker-run-env.sh ${{ matrix.distro }} ./build-env/bin/build-all.sh --deps --install --build --source --arch=${{ matrix.arch }}
+          export DOCKER_OPTS='-i'; ./build-env/bin/docker-run-env.sh ${{ matrix.distro }} ./build-env/bin/build-all.sh --install --arch=${{ matrix.arch }}
   build-rpms:
     runs-on: ubuntu-latest
     strategy:
@@ -68,4 +68,4 @@ jobs:
           echo "$UPDATE_DEFAULT_RESOURCES" > update_default_resources.c
       - name: Build
         run: |
-          export DOCKER_OPTS='-i'; ./build-env/bin/docker-run-env.sh -a ${{ matrix.arch }} ${{ matrix.distro }} ./build-env/bin/build-all.sh --deps --install --build --source --arch=${{ matrix.arch }}
+          export DOCKER_OPTS='-i'; ./build-env/bin/docker-run-env.sh -a ${{ matrix.arch }} ${{ matrix.distro }} ./build-env/bin/build-all.sh --install --arch=${{ matrix.arch }}

--- a/tarball/patches/sethostname.patch
+++ b/tarball/patches/sethostname.patch
@@ -6,16 +6,15 @@ Index: pelion-edge-amd64/usr/bin/generate-identity.sh
 ===================================================================
 --- pelion-edge-amd64.orig/usr/bin/generate-identity.sh
 +++ pelion-edge-amd64/usr/bin/generate-identity.sh
-@@ -57,6 +57,12 @@ execute () {
-             if [ -f ${IDENTITY_DIR}/identity.json ] ; then
+@@ -61,6 +61,11 @@ execute () {
                  cp ${IDENTITY_DIR}/identity.json ${IDENTITY_DIR}/identity_original.json
              fi
-+
+ 
 +            if ! grep -q "$internalid" /etc/hosts; then
-+                sed -i '/Pelion Edge/d' /etc/hosts && \
++                 sed -i '/Pelion Edge/d' /etc/hosts && \
 +                echo "127.1.2.7 $internalid # Pelion Edge" >> /etc/hosts
 +            fi 2>/dev/null
 +
-             IFS='.' read -ra ADDR <<< "$lwm2mserveruri"
-             /usr/lib/pelion/developer_identity/create-dev-identity.sh\
-                 -d \
+             [[ $lwm2mserveruri == *"lwm2m"* ]] && commonaddr=${lwm2mserveruri#"lwm2m"}
+             [[ $lwm2mserveruri == *"udp-lwm2m"* ]] && commonaddr=${lwm2mserveruri#"udp-lwm2m"}
+             [[ $lwm2mserveruri == *"tcp-lwm2m"* ]] && commonaddr=${lwm2mserveruri#"tcp-lwm2m"}


### PR DESCRIPTION
By specifically including --build --source --deps, we inadvertently
turned off the tarball build.  By leaving out --build --source --deps it
implies everything[1] including --tar.

[1] https://github.com/PelionIoT/distro-pelion-edge#building-all-packages