### PR TITLE
Fix tar build error when applying patch

### DIFF
--- a/tarball/patches/sethostname.patch
+++ b/tarball/patches/sethostname.patch
@@ -6,16 +6,15 @@ Index: pelion-edge-amd64/usr/bin/generate-identity.sh
 ===================================================================
 --- pelion-edge-amd64.orig/usr/bin/generate-identity.sh
 +++ pelion-edge-amd64/usr/bin/generate-identity.sh
-@@ -57,6 +57,12 @@ execute () {
-             if [ -f ${IDENTITY_DIR}/identity.json ] ; then
+@@ -61,6 +61,11 @@ execute () {
                  cp ${IDENTITY_DIR}/identity.json ${IDENTITY_DIR}/identity_original.json
              fi
-+
+ 
 +            if ! grep -q "$internalid" /etc/hosts; then
-+                sed -i '/Pelion Edge/d' /etc/hosts && \
++                 sed -i '/Pelion Edge/d' /etc/hosts && \
 +                echo "127.1.2.7 $internalid # Pelion Edge" >> /etc/hosts
 +            fi 2>/dev/null
 +
-             IFS='.' read -ra ADDR <<< "$lwm2mserveruri"
-             /usr/lib/pelion/developer_identity/create-dev-identity.sh\
-                 -d \
+             [[ $lwm2mserveruri == *"lwm2m"* ]] && commonaddr=${lwm2mserveruri#"lwm2m"}
+             [[ $lwm2mserveruri == *"udp-lwm2m"* ]] && commonaddr=${lwm2mserveruri#"udp-lwm2m"}
+             [[ $lwm2mserveruri == *"tcp-lwm2m"* ]] && commonaddr=${lwm2mserveruri#"tcp-lwm2m"}


### PR DESCRIPTION
Fix for patch contents sethostname.patch after updates in source file of generate-identity.sh in pe-utils repository. Issue #199 