### PR TITLE
Lock down floating dependencies

### DIFF
--- a/build-env/docker/docker-debian-10-buster/preferences
+++ b/build-env/docker/docker-debian-10-buster/preferences
@@ -1,87 +1,87 @@
 Package: *
-Pin: release a=stable
+Pin: release n=buster
 Pin-Priority: 800
 
 Package: golang-1.14-go
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-1.14-src
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: debhelper
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: dh-golang
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-dbus-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-ginkgo-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-alexflint-go-filemutex-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-appc-cni-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-coreos-go-iptables-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-coreos-go-systemd-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-d2g-dhcp4client-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-d2g-dhcp4-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-j-keck-arping-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-mattn-go-shellwords-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-safchain-ethtool-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-vishvananda-netlink-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-golang-x-sys-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-gomega-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-onsi-ginkgo-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-hpcloud-tail-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900
 
 Package: golang-github-influxdata-tail-dev
-Pin: release a=testing
+Pin: release n=bullseye
 Pin-Priority: 900


### PR DESCRIPTION
Debian just released bullseye as stable so now "stable" points to an
entirely different version.  Instead of using stable/testing/unstable we
should use the actual release names(ex: stretch, buster, bullseye) so
that when Debian releases the build doesn't break.