### PR TITLE
lock down floating Dockerfile base image versions

### DIFF
--- a/build-env/docker/docker-debian-10-buster/Dockerfile.build
+++ b/build-env/docker/docker-debian-10-buster/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM debian:10
+FROM debian:buster-20210816
 
 ARG USER_ID
 ARG GROUP_ID

--- a/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-18-bionic/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:bionic-20210723
 
 ARG USER_ID
 ARG GROUP_ID

--- a/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
+++ b/build-env/docker/docker-ubuntu-20-focal/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:focal-20210723
 
 ARG USER_ID
 ARG GROUP_ID

--- a/build-env/target/centos/8/Dockerfile.amd64
+++ b/build-env/target/centos/8/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM amd64/centos:8
+FROM amd64/centos:8.3.2011
 
 ARG USER_ID
 ARG GROUP_ID

--- a/build-env/target/centos/8/Dockerfile.arm64
+++ b/build-env/target/centos/8/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/centos:8
+FROM arm64v8/centos:8.3.2011
 
 ARG USER_ID
 ARG GROUP_ID

--- a/build-env/target/rhel/8/Dockerfile.amd64
+++ b/build-env/target/rhel/8/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:8.4-209
 
 ARG USER_ID
 ARG GROUP_ID

--- a/build-env/target/rhel/8/Dockerfile.arm64
+++ b/build-env/target/rhel/8/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:8.4-209
 
 ARG USER_ID
 ARG GROUP_ID


### PR DESCRIPTION
In order to be able to reproduce a build, every dependency must be
pinned to a specific version and not allowed to float.  Select docker
image tags that don't change.