### PR TITLE
debian-11 fixup: Remove Acquire::Check-Valid-Until "0"

### DIFF
--- a/build-env/docker/docker-debian-11-bullseye/Dockerfile.build
+++ b/build-env/docker/docker-debian-11-bullseye/Dockerfile.build
@@ -13,8 +13,7 @@ RUN if [ $GROUP_ID != $DOCKER_GROUP_ID ]; then usermod -aG docker user; fi
 
 RUN echo "APT::Acquire::Retries \"3\";" > /etc/apt/apt.conf.d/80-retries
 COPY $LOCAL_SRC_PATH/sources.list.bullseye /etc/apt/sources.list
-COPY $LOCAL_SRC_PATH/apt.conf.d/10-no-check-valid-until /etc/apt/apt.conf.d/10-no-check-valid-until
-RUN chmod 644 /etc/apt/sources.list /etc/apt/apt.conf.d/10-no-check-valid-until
+RUN chmod 644 /etc/apt/sources.list
 RUN mkdir -p /opt/apt-repo/pe-dependencies && echo -n| gzip >/opt/apt-repo/pe-dependencies/Packages.gz && find /opt && apt-get update
 
 RUN dpkg --add-architecture arm64

--- a/build-env/docker/docker-debian-11-bullseye/apt.conf.d/10-no-check-valid-until
+++ b/build-env/docker/docker-debian-11-bullseye/apt.conf.d/10-no-check-valid-until
@@ -1,2 +1,0 @@
-# ignore "valid until" timestamp so that installing from snapshot will work
-Acquire::Check-Valid-Until "0";


### PR DESCRIPTION
We don't need this in bullseye since we're not using snapshots in
bullseye.