### PR TITLE
Remove temporary Kubelet images and containers after build

### DIFF
--- a/kubelet/deb/debian/auto_build
+++ b/kubelet/deb/debian/auto_build
@@ -35,3 +35,5 @@ fi
 
 echo "cp $from_path $origpath/"
 cp "$from_path" "$origpath"/
+
+build/make-clean.sh


### PR DESCRIPTION
Kubelet build creates temporary image and container for each build and by default does not remove them. This change runs cleanup scripts after successful build to remove these temporary data