### PR TITLE
ci: add manual amd64 deb build + MinIO publish workflow

### DIFF
--- a/.github/workflows/build-amd64-publish-minio.yml
+++ b/.github/workflows/build-amd64-publish-minio.yml
@@ -47,14 +47,22 @@ jobs:
 
       - name: Copy mbed_cloud_dev_credentials.c
         env:
-          MBED_CLOUD_DEV_CREDENTIALS: ${{ secrets.MBED_CLOUD_DEV_CREDENTIALS_C_RYAN }}
+          MBED_CLOUD_DEV_CREDENTIALS: ${{ secrets.MBED_CLOUD_DEV_CREDENTIALS_STAGING_IZUMA_BOT }}
         run: |
+          if [ -z "$MBED_CLOUD_DEV_CREDENTIALS" ]; then
+            echo "MBED_CLOUD_DEV_CREDENTIALS_STAGING_IZUMA_BOT is empty or unset" >&2
+            exit 1
+          fi
           echo "$MBED_CLOUD_DEV_CREDENTIALS" > mbed_cloud_dev_credentials.c
 
       - name: Copy update_default_resources.c
         env:
-          UPDATE_DEFAULT_RESOURCES: ${{ secrets.UPDATE_DEFAULT_RESOURCES_C_RYAN }}
+          UPDATE_DEFAULT_RESOURCES: ${{ secrets.UPDATE_DEFAULT_RESOURCES_STAGING_IZUMA_BOT }}
         run: |
+          if [ -z "$UPDATE_DEFAULT_RESOURCES" ]; then
+            echo "UPDATE_DEFAULT_RESOURCES_STAGING_IZUMA_BOT is empty or unset" >&2
+            exit 1
+          fi
           echo "$UPDATE_DEFAULT_RESOURCES" > update_default_resources.c
 
       - name: Build

--- a/.github/workflows/build-amd64-publish-minio.yml
+++ b/.github/workflows/build-amd64-publish-minio.yml
@@ -1,0 +1,181 @@
+name: Build amd64 debs and publish to MinIO
+
+# Manual only: pick the branch/tag from the "Run workflow" ref dropdown.
+on:
+  workflow_dispatch:
+    inputs:
+      distro:
+        description: 'Distro codename to build for'
+        type: choice
+        options:
+          - bullseye
+          - focal
+        default: bullseye
+      prefix:
+        description: >-
+          Path prefix inside the bucket. Empty publishes to the canonical
+          deb/<distro>/main/ layout; set something like "staging" to park a
+          branch build somewhere harmless.
+        type: string
+        required: false
+        default: ''
+      upload_tarball:
+        description: 'Also upload the pelion-edge tarball (under tar/)'
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Build and list what would be uploaded, but do not upload'
+        type: boolean
+        default: false
+
+jobs:
+  build-and-publish:
+    # MinIO lives on a private address, so this needs a runner that can reach
+    # it. Override with the BUILD_RUNNER repo variable (e.g. self-hosted).
+    runs-on: ${{ vars.BUILD_RUNNER || 'ubuntu-22.04' }}
+    env:
+      DISTRO: ${{ inputs.distro }}
+      ARCH: amd64
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set access token for internal repo access
+        uses: PelionIoT/actions/.github/actions/git-config@main
+        with:
+          github_token: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: Copy mbed_cloud_dev_credentials.c
+        env:
+          MBED_CLOUD_DEV_CREDENTIALS: ${{ secrets.MBED_CLOUD_DEV_CREDENTIALS_C_RYAN }}
+        run: |
+          echo "$MBED_CLOUD_DEV_CREDENTIALS" > mbed_cloud_dev_credentials.c
+
+      - name: Copy update_default_resources.c
+        env:
+          UPDATE_DEFAULT_RESOURCES: ${{ secrets.UPDATE_DEFAULT_RESOURCES_C_RYAN }}
+        run: |
+          echo "$UPDATE_DEFAULT_RESOURCES" > update_default_resources.c
+
+      - name: Build
+        run: |
+          export DOCKER_OPTS='-i'
+          ./build-env/bin/docker-run-env.sh "$DISTRO" \
+            ./build-env/bin/build-all.sh --install --arch="$ARCH"
+          docker system prune -f
+
+      - name: Cleanup .gitconfig
+        if: always()
+        run: rm -f ~/.gitconfig
+
+      # The build runs inside containers as a different uid; make the outputs
+      # readable by the runner user before we stage them.
+      - name: Fix ownership of build outputs
+        run: sudo chown -R "$(id -u):$(id -g)" build
+
+      # The MinIO layout mirrors build/deploy/deb/<distro>/main/ exactly
+      # (binary-amd64/, binary-all/, source/, including the .lintian reports),
+      # so we publish that directory as-is.
+      - name: Inspect build output
+        id: stage
+        run: |
+          set -euo pipefail
+          deb_dir="build/deploy/deb/$DISTRO/main"
+
+          if [ ! -d "$deb_dir" ]; then
+            echo "Expected build output at $deb_dir, but it does not exist" >&2
+            ls -R build/deploy 2>/dev/null || true
+            exit 1
+          fi
+
+          shopt -s nullglob
+          debs=( "$deb_dir/binary-$ARCH"/*.deb "$deb_dir/binary-all"/*.deb )
+          if [ ${#debs[@]} -eq 0 ]; then
+            echo "No .deb files found under $deb_dir" >&2
+            exit 1
+          fi
+          echo "Built ${#debs[@]} package(s):"
+          printf '  %s\n' "${debs[@]}"
+
+          echo "deb_dir=$deb_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts to the workflow run
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.distro }}-amd64-debs
+          path: build/deploy/deb/${{ inputs.distro }}/main/
+          if-no-files-found: error
+
+      - name: Install MinIO client
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/bin"
+          curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc \
+            -o "$RUNNER_TEMP/bin/mc"
+          chmod +x "$RUNNER_TEMP/bin/mc"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/mc" --version
+
+      - name: Publish to MinIO
+        env:
+          MINIO_ENDPOINT: ${{ vars.MINIO_ENDPOINT }}
+          MINIO_ACCESS_KEY: ${{ secrets.MINIO_ACCESS_KEY }}
+          MINIO_SECRET_KEY: ${{ secrets.MINIO_SECRET_KEY }}
+          BUCKET: ${{ vars.MINIO_BUCKET }}
+          PREFIX: ${{ inputs.prefix }}
+          DEB_DIR: ${{ steps.stage.outputs.deb_dir }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          for v in MINIO_ENDPOINT MINIO_ACCESS_KEY MINIO_SECRET_KEY BUCKET; do
+            if [ -z "${!v}" ]; then
+              echo "$v is not set (configure it in the repo's Actions settings)" >&2
+              exit 1
+            fi
+          done
+
+          dest="minio/$BUCKET"
+          if [ -n "$PREFIX" ]; then
+            dest="$dest/${PREFIX%/}"
+          fi
+          dest="$dest/deb/$DISTRO/main"
+
+          mc alias set minio "$MINIO_ENDPOINT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run - would upload $DEB_DIR/ to $dest/"
+            ( cd "$DEB_DIR" && find . -type f | sort | sed 's|^\./|  |' )
+            exit 0
+          fi
+
+          # Additive copy: existing objects for other versions are untouched,
+          # objects with the same name are replaced.
+          mc cp --recursive "$DEB_DIR/" "$dest/"
+
+          if [ "${{ inputs.upload_tarball }}" = "true" ]; then
+            tarball="build/deploy/tar/pelion-edge-$DISTRO-$ARCH.tar.gz"
+            if [ -f "$tarball" ]; then
+              tar_dest="minio/$BUCKET"
+              if [ -n "$PREFIX" ]; then
+                tar_dest="$tar_dest/${PREFIX%/}"
+              fi
+              mc cp "$tarball" "$tar_dest/tar/"
+            else
+              echo "::warning::No tarball found at $tarball"
+            fi
+          fi
+
+          {
+            echo "### Published to MinIO"
+            echo ""
+            echo "\`$dest/\` (from \`${GITHUB_REF_NAME}\` @ \`${GITHUB_SHA:0:8}\`)"
+            echo ""
+            echo '```'
+            mc ls --recursive "$dest/"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Remove MinIO credentials
+        if: always()
+        run: mc alias remove minio || true

--- a/.github/workflows/build-amd64-publish-minio.yml
+++ b/.github/workflows/build-amd64-publish-minio.yml
@@ -11,11 +11,33 @@ on:
           - bullseye
           - focal
         default: bullseye
+      package:
+        description: 'Package to build ("all" builds everything)'
+        type: choice
+        default: all
+        options:
+          - all
+          - edge-proxy
+          - pe-terminal
+          - kubelet
+          - edge-resource-manager
+          - mbed-edge-core
+          - mbed-edge-core-devmode
+          - mbed-edge-core-byocmode
+          - golang-github-containernetworking-plugins
+          - mbed-edge-examples
+          - mbed-fcc
+          - pe-utils
+          - fluent-bit
+          - metapackages/pelion-edge
+          - metapackages/pelion-edge-base
+          - metapackages/pelion-edge-container-orchestration
+          - metapackages/pelion-edge-protocol-engine
       packages:
         description: >-
-          Space/comma separated packages to build, e.g.
-          "edge-proxy pe-utils". Leave empty to build everything. Accepts
-          metapackages/<name> and golang-providers/<name> too.
+          Several packages, space/comma separated, e.g. "edge-proxy
+          pe-utils". Overrides the dropdown when set. Accepts anything with
+          a <name>/deb/build.sh, including golang-providers/<name>.
         type: string
         required: false
         default: ''
@@ -73,9 +95,34 @@ jobs:
           fi
           echo "$UPDATE_DEFAULT_RESOURCES" > update_default_resources.c
 
+      # The dropdown is single-select, so the free-text field takes precedence
+      # when someone needs to build several packages in one run.
+      - name: Resolve package selection
+        id: selection
+        env:
+          PACKAGE_CHOICE: ${{ inputs.package }}
+          PACKAGES_INPUT: ${{ inputs.packages }}
+        run: |
+          set -euo pipefail
+          selection="$PACKAGES_INPUT"
+          if [ -z "$selection" ] && [ "$PACKAGE_CHOICE" != "all" ]; then
+            selection="$PACKAGE_CHOICE"
+          fi
+
+          if [ -n "$PACKAGES_INPUT" ] && [ "$PACKAGE_CHOICE" != "all" ]; then
+            echo "::notice::Both inputs set; building '$PACKAGES_INPUT' and ignoring the '$PACKAGE_CHOICE' dropdown selection."
+          fi
+
+          if [ -z "$selection" ]; then
+            echo "Building all packages"
+          else
+            echo "Building: $selection"
+          fi
+          echo "packages=$selection" >> "$GITHUB_OUTPUT"
+
       - name: Validate package selection
         env:
-          PACKAGES_INPUT: ${{ inputs.packages }}
+          PACKAGES_INPUT: ${{ steps.selection.outputs.packages }}
         run: |
           set -euo pipefail
           [ -n "$PACKAGES_INPUT" ] || exit 0
@@ -105,7 +152,7 @@ jobs:
 
       - name: Build
         env:
-          PACKAGES_INPUT: ${{ inputs.packages }}
+          PACKAGES_INPUT: ${{ steps.selection.outputs.packages }}
         run: |
           set -euo pipefail
           export DOCKER_OPTS='-i'
@@ -114,7 +161,8 @@ jobs:
           if [ -z "$PACKAGES_INPUT" ]; then
             run_env ./build-env/bin/build-all.sh --install --arch="$ARCH"
           else
-            # Go packages resolve golang-virtual from the local apt repo, so the
+            # Go packages resolve the golang provider (pe-golang-bin on
+            # bullseye, golang-virtual on focal) from the local apt repo, so the
             # dependency stage has to run even for a single-package build.
             echo "::group::Dependencies"
             run_env ./build-env/bin/build-all.sh --install --arch="$ARCH" --deps

--- a/.github/workflows/build-amd64-publish-minio.yml
+++ b/.github/workflows/build-amd64-publish-minio.yml
@@ -11,6 +11,14 @@ on:
           - bullseye
           - focal
         default: bullseye
+      packages:
+        description: >-
+          Space/comma separated packages to build, e.g.
+          "edge-proxy pe-utils". Leave empty to build everything. Accepts
+          metapackages/<name> and golang-providers/<name> too.
+        type: string
+        required: false
+        default: ''
       prefix:
         description: >-
           Path prefix inside the bucket. Empty publishes to the canonical
@@ -65,11 +73,64 @@ jobs:
           fi
           echo "$UPDATE_DEFAULT_RESOURCES" > update_default_resources.c
 
-      - name: Build
+      - name: Validate package selection
+        env:
+          PACKAGES_INPUT: ${{ inputs.packages }}
         run: |
+          set -euo pipefail
+          [ -n "$PACKAGES_INPUT" ] || exit 0
+
+          # A partial build only populates binary-<arch>/ with the packages
+          # selected, but deb2tar globs that directory to assemble a whole
+          # rootfs - the tarball would look valid and silently miss components.
+          if [ "${{ inputs.upload_tarball }}" = "true" ]; then
+            echo "upload_tarball cannot be combined with a package selection:" >&2
+            echo "the tarball is assembled from every built .deb and would be incomplete." >&2
+            exit 1
+          fi
+
+          invalid=()
+          for pkg in $(printf '%s' "$PACKAGES_INPUT" | tr ',' ' '); do
+            [ -f "$pkg/deb/build.sh" ] || invalid+=( "$pkg" )
+          done
+
+          if [ ${#invalid[@]} -gt 0 ]; then
+            echo "Unknown package(s): ${invalid[*]}" >&2
+            echo "" >&2
+            echo "Available:" >&2
+            find . -path '*/deb/build.sh' -not -path './build/*' 2>/dev/null \
+              | sed 's|^\./||;s|/deb/build.sh$||' | sort -u | sed 's/^/  /' >&2
+            exit 1
+          fi
+
+      - name: Build
+        env:
+          PACKAGES_INPUT: ${{ inputs.packages }}
+        run: |
+          set -euo pipefail
           export DOCKER_OPTS='-i'
-          ./build-env/bin/docker-run-env.sh "$DISTRO" \
-            ./build-env/bin/build-all.sh --install --arch="$ARCH"
+          run_env() { ./build-env/bin/docker-run-env.sh "$DISTRO" "$@"; }
+
+          if [ -z "$PACKAGES_INPUT" ]; then
+            run_env ./build-env/bin/build-all.sh --install --arch="$ARCH"
+          else
+            # Go packages resolve golang-virtual from the local apt repo, so the
+            # dependency stage has to run even for a single-package build.
+            echo "::group::Dependencies"
+            run_env ./build-env/bin/build-all.sh --install --arch="$ARCH" --deps
+            echo "::endgroup::"
+
+            for pkg in $(printf '%s' "$PACKAGES_INPUT" | tr ',' ' '); do
+              echo "::group::Build $pkg"
+              case "$pkg" in
+                # Metapackages are Architecture: all and take no --arch.
+                metapackages/*) run_env "./$pkg/deb/build.sh" --install ;;
+                *)              run_env "./$pkg/deb/build.sh" --install --arch="$ARCH" ;;
+              esac
+              echo "::endgroup::"
+            done
+          fi
+
           docker system prune -f
 
       - name: Cleanup .gitconfig


### PR DESCRIPTION
## Summary

Adds `.github/workflows/build-amd64-publish-minio.yml`: a manually-triggered workflow that builds the amd64 Debian packages and publishes them to the `edge-debian-pkg` MinIO bucket.

- **Manual only** — no push trigger. The branch/tag is chosen from the standard "Run workflow" ref dropdown.
- **Build steps mirror `build.yml`**, restricted to one distro and `amd64`.
- **Package selection** — build everything, or pick one from a dropdown, or name several.
- **Publish is a straight mirror.** The bucket layout already matches `build/deploy/deb/<distro>/main/` 1:1 — `binary-amd64/`, `binary-all/`, `source/`, including the `.lintian` reports — so the directory is uploaded as-is with `mc cp --recursive`.
- Everything is also attached as a workflow run artifact, so the packages are retrievable without MinIO access.

## Inputs

| Input | Default | Purpose |
|---|---|---|
| `distro` | `bullseye` | `bullseye` or `focal` |
| `package` | `all` | Dropdown of every package and metapackage the build config declares |
| `packages` | *(empty)* | Several packages, space/comma separated, e.g. `edge-proxy pe-utils`. Overrides the dropdown |
| `prefix` | *(empty)* | Empty publishes to the canonical `deb/<distro>/main/`; set e.g. `staging` to park a branch build elsewhere |
| `upload_tarball` | `false` | Also upload `pelion-edge-<distro>-amd64.tar.gz` under `tar/` |
| `dry_run` | `false` | Build and list what would be uploaded, without uploading |

### Package selection

GitHub Actions has no multi-select input type, so `package` is a single-select dropdown covering the common case, and `packages` remains free text for building several at once. When both are set the free-text field wins and the run logs a notice saying so.

Selected packages are built through their own `<pkg>/deb/build.sh` — the same entry point `run_group` uses — rather than `build-all.sh`. That convention holds for metapackages and dependencies too, so `golang-providers/pe-golang-bin` is a valid free-text selection even though dependency packages are omitted from the dropdown (the deps stage runs automatically). Metapackages are `Architecture: all` and take no `--arch`, so they're dispatched without it. Unknown names fail fast with the list of valid ones.

Two behaviours worth knowing:

- **The dependency stage still runs** in selective mode, via `build-all.sh --deps`. Go packages resolve the golang provider from the local apt repo, and which provider that is depends on the distro — `pe-golang-bin` on bullseye, `golang-virtual` on focal — so this delegates rather than naming one.
- **A package selection plus `upload_tarball` is refused.** `deb2tar` globs `binary-<arch>/` to assemble a full rootfs, so a partial build would produce a tarball that looks valid but silently misses components.

Because the checkout is fresh, a selective build leaves only the selected packages in `build/deploy`, so the publish step naturally uploads just those — the rest of the bucket is untouched.

## Configuration required before this can run

Repo variables: `MINIO_ENDPOINT` (`http://10.7.114.79:9000`), `MINIO_BUCKET` (`edge-debian-pkg`), and `BUILD_RUNNER`.
Repo secrets: `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` — scoped to the bucket.

Dev certificates come from `MBED_CLOUD_DEV_CREDENTIALS_STAGING_IZUMA_BOT` and `UPDATE_DEFAULT_RESOURCES_STAGING_IZUMA_BOT` rather than the `_C_RYAN` secrets that `build.yml` uses. **`UPDATE_DEFAULT_RESOURCES_STAGING_IZUMA_BOT` does not currently exist as a repo secret** — it needs creating, or confirming that it resolves at org level. The workflow fails fast with a clear message if either is empty.

`ACCESS_TOKEN` is reused unchanged.

## Notes for reviewers

- **`runs-on` is `${{ vars.BUILD_RUNNER || 'ubuntu-22.04' }}`.** The MinIO endpoint is an RFC1918 address, which GitHub-hosted runners cannot reach, so `BUILD_RUNNER` needs to point at a runner on the network. The default is only a fallback.
- **The bucket layout is flat and version-keyed, not run-scoped.** Objects accumulate by version (`pe-utils_2.3.8`, `2.3.9`, …), so a branch build that produces an already-published version will replace that object. `prefix` and `dry_run` exist to make that avoidable rather than accidental.
- **Metapackages are selectable but declare dependencies on the real packages**, so verification may fail if one is built in isolation. They're most reliable in a full build; left selectable since rebuilding one after a changelog bump is legitimate.
- **The bucket currently only contains `focal` artifacts**, but the default here is `bullseye` per the requested scope; both are selectable.

## Testing

The workflow's shell logic was exercised locally against the real repo layout and a synthetic `build/deploy` tree: selection precedence between the dropdown and the free-text field, package-selection validation (space and comma separated, metapackages, dependency packages, unknown names, the tarball conflict), build-command dispatch for each package kind, destination-path construction with and without a prefix, dry-run listing, missing-configuration failures, and branch names containing `/` and special characters.

The dropdown options were cross-checked against the `PACKAGES` and `METAPACKAGES` arrays in `debian_packages.conf.sh` — they match exactly, with no extras or omissions, and every option resolves to a real `deb/build.sh`. The YAML parses, and the 6 inputs are within the 10-input `workflow_dispatch` limit.

The full package build and a real upload have **not** been run — those need Docker, the org secrets, and network access to the endpoint. The first dispatch (ideally with `dry_run: true`) is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)